### PR TITLE
add cookiecutter template for creating new extensions

### DIFF
--- a/template/cookiecutter.json
+++ b/template/cookiecutter.json
@@ -1,0 +1,10 @@
+{
+  "project_name": "My LocalStack Extension",
+  "project_short_description": "All the boilerplate you need to create a LocalStack extension.",
+  "project_slug": "{{ cookiecutter.project_name.lower().replace(' ', '-') }}",
+  "module_name": "{{ cookiecutter.project_slug.replace('-', '_') }}",
+  "full_name": "Jane Doe",
+  "email": "jane@example.com",
+  "github_username": "janedoe",
+  "version": "0.1.0"
+}

--- a/template/{{cookiecutter.project_slug}}/Makefile
+++ b/template/{{cookiecutter.project_slug}}/Makefile
@@ -1,0 +1,32 @@
+VENV_BIN = python3 -m venv
+VENV_DIR ?= .venv
+VENV_ACTIVATE = $(VENV_DIR)/bin/activate
+VENV_RUN = . $(VENV_ACTIVATE)
+
+venv: $(VENV_ACTIVATE)
+
+$(VENV_ACTIVATE): setup.py setup.cfg
+	test -d .venv || $(VENV_BIN) .venv
+	$(VENV_RUN); pip install --upgrade pip setuptools plux
+	$(VENV_RUN); pip install -e .
+	touch $(VENV_DIR)/bin/activate
+
+clean:
+	rm -rf .venv/
+	rm -rf build/
+	rm -rf .eggs/
+	rm -rf *.egg-info/
+
+install: venv
+	$(VENV_RUN); python setup.py develop
+
+dist: venv
+	$(VENV_RUN); python setup.py sdist bdist_wheel
+
+publish: clean-dist venv dist
+	$(VENV_RUN); pip install --upgrade twine; twine upload dist/*
+
+clean-dist: clean
+	rm -rf dist/
+
+.PHONY: clean clean-dist dist install publish

--- a/template/{{cookiecutter.project_slug}}/README.md
+++ b/template/{{cookiecutter.project_slug}}/README.md
@@ -1,0 +1,19 @@
+{{ cookiecutter.project_name }}
+===============================
+
+{{ cookiecutter.project_short_description }}
+
+## Install from GitHub repository
+
+```bash
+localstack extensions install "git+https://github.com/{{cookiecutter.github_username }}/{{ cookiecutter.project_slug }}/#egg={{ cookiecutter.project_slug }}"
+```
+
+## Install local development version
+
+```bash
+localstack extensions dev enable .
+```
+
+```bash
+EXTENSION_DEV_MODE=1 localstack start

--- a/template/{{cookiecutter.project_slug}}/setup.cfg
+++ b/template/{{cookiecutter.project_slug}}/setup.cfg
@@ -1,0 +1,19 @@
+[metadata]
+name = {{ cookiecutter.project_slug }}
+version = {{ cookiecutter.version }}
+url = https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}
+author = {{ cookiecutter.full_name }}
+author_email = {{ cookiecutter.email }}
+description = {{ cookiecutter.project_short_description }}
+long_description = file: README.md
+long_description_content_type = text/markdown; charset=UTF-8
+
+[options]
+zip_safe = False
+packages = find:
+install_requires =
+    localstack>=1.0
+
+[options.entry_points]
+localstack.extensions =
+    {{ cookiecutter.project_slug }} = {{ cookiecutter.module_name }}.extension:MyExtension

--- a/template/{{cookiecutter.project_slug}}/setup.py
+++ b/template/{{cookiecutter.project_slug}}/setup.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env python
+from setuptools import setup
+
+setup()

--- a/template/{{cookiecutter.project_slug}}/{{cookiecutter.module_name}}/__init__.py
+++ b/template/{{cookiecutter.project_slug}}/{{cookiecutter.module_name}}/__init__.py
@@ -1,0 +1,1 @@
+name = "{{ cookiecutter.module_name }}"

--- a/template/{{cookiecutter.project_slug}}/{{cookiecutter.module_name}}/extension.py
+++ b/template/{{cookiecutter.project_slug}}/{{cookiecutter.module_name}}/extension.py
@@ -1,0 +1,22 @@
+from localstack.extensions.api import Extension, http, aws
+
+class MyExtension(Extension):
+    name = "{{ cookiecutter.project_slug }}"
+
+    def on_extension_load(self):
+        print("MyExtension: extension is loaded")
+
+    def on_platform_start(self):
+        print("MyExtension: localstack is starting")
+
+    def on_platform_ready(self):
+        print("MyExtension: localstack is running")
+
+    def update_gateway_routes(self, router: http.Router[http.RouteHandler]):
+        pass
+
+    def update_request_handlers(self, handlers: aws.CompositeHandler):
+        pass
+
+    def update_response_handlers(self, handlers: aws.CompositeResponseHandler):
+        pass


### PR DESCRIPTION
This is a template for new extensions. It contains a really basic python distribution config and a barebone Extension implementation.

You can use it either via cookiecutter directly:

```console
cookiecutter git@github.com:localstack/localstack-extensions --directory template
```

or, with the new localstack-ext dev commands (comming soon:tm:)

```console
localstack extensions dev new
```

I could imagine that moving forward we may have something like the [maven archetype](https://maven.apache.org/guides/introduction/introduction-to-archetypes.html), so a framework around templates.