### PR TITLE
add diagnosis viewer extensions based on diapretty

### DIFF
--- a/diagnosis-viewer/Makefile
+++ b/diagnosis-viewer/Makefile
@@ -1,0 +1,32 @@
+VENV_BIN = python3 -m venv
+VENV_DIR ?= .venv
+VENV_ACTIVATE = $(VENV_DIR)/bin/activate
+VENV_RUN = . $(VENV_ACTIVATE)
+
+venv: $(VENV_ACTIVATE)
+
+$(VENV_ACTIVATE): setup.py setup.cfg
+	test -d .venv || $(VENV_BIN) .venv
+	$(VENV_RUN); pip install --upgrade pip setuptools plux
+	$(VENV_RUN); pip install -e .
+	touch $(VENV_DIR)/bin/activate
+
+clean:
+	rm -rf .venv/
+	rm -rf build/
+	rm -rf .eggs/
+	rm -rf *.egg-info/
+
+install: venv
+	$(VENV_RUN); python setup.py develop
+
+dist: venv
+	$(VENV_RUN); python setup.py sdist bdist_wheel
+
+publish: clean-dist venv dist
+	$(VENV_RUN); pip install --upgrade twine; twine upload dist/*
+
+clean-dist: clean
+	rm -rf dist/
+
+.PHONY: clean clean-dist dist install publish

--- a/diagnosis-viewer/README.md
+++ b/diagnosis-viewer/README.md
@@ -19,10 +19,11 @@ Then, to enable the extension for LocalStack, run
 localstack extensions dev enable .
 ```
 
-You can then start LocalStack with `EXTENSION_DEV_MODE=1` to load all enabled extensions:
+You can then start LocalStack with `EXTENSION_DEV_MODE=1` to load all enabled extensions.
+Make sure to also set `DEBUG=1` so the diagnose endpoint necessary to populate the report is loaded.
 
 ```bash
-EXTENSION_DEV_MODE=1 localstack start
+EXTENSION_DEV_MODE=1 DEBUG=1 localstack start
 ```
 
 ## Install from GitHub repository

--- a/diagnosis-viewer/README.md
+++ b/diagnosis-viewer/README.md
@@ -1,0 +1,34 @@
+Diagnosis Viewer
+===============================
+
+View the diagnostics endpoint directly in localstack
+
+## Install local development version
+
+To install the extension into localstack in developer mode, you will need Python 3.10, and create a virtual environment in the extensions project.
+
+In the newly generated project, simply run
+
+```bash
+make install
+```
+
+Then, to enable the extension for LocalStack, run
+
+```bash
+localstack extensions dev enable .
+```
+
+You can then start LocalStack with `EXTENSION_DEV_MODE=1` to load all enabled extensions:
+
+```bash
+EXTENSION_DEV_MODE=1 localstack start
+```
+
+## Install from GitHub repository
+
+To distribute your extension, simply upload it to your github account. Your extension can then be installed via:
+
+```bash
+localstack extensions install "git+https://github.com/localstack/diagnosis-viewer/#egg=diagnosis-viewer"
+```

--- a/diagnosis-viewer/README.md
+++ b/diagnosis-viewer/README.md
@@ -26,6 +26,11 @@ Make sure to also set `DEBUG=1` so the diagnose endpoint necessary to populate t
 EXTENSION_DEV_MODE=1 DEBUG=1 localstack start
 ```
 
+## Access Diagnosis Data
+
+The extension is a web UI for the diagnosis endpoint of LocalStack, which is enabled when LocalStack is started with `DEBUG=1` and available at `curl -s localhost:4566/_localstack/diagnose`.
+The web UI can then be reached at `http://localhost:4566/diapretty`.
+
 ## Install from GitHub repository
 
 To distribute your extension, simply upload it to your github account. Your extension can then be installed via:

--- a/diagnosis-viewer/diagnosis_viewer/__init__.py
+++ b/diagnosis-viewer/diagnosis_viewer/__init__.py
@@ -1,0 +1,1 @@
+name = "diagnosis_viewer"

--- a/diagnosis-viewer/diagnosis_viewer/extension.py
+++ b/diagnosis-viewer/diagnosis_viewer/extension.py
@@ -1,0 +1,14 @@
+import logging
+
+from localstack.extensions.api import Extension, http
+
+LOG = logging.getLogger(__name__)
+
+
+class DiagnosisViewerExtension(Extension):
+    name = "diagnosis-viewer"
+
+    def update_gateway_routes(self, router: http.Router[http.RouteHandler]):
+        from diapretty.server.api import DiagnoseServer
+        api = DiagnoseServer()
+        router.add("/diapretty", api.serve)

--- a/diagnosis-viewer/setup.cfg
+++ b/diagnosis-viewer/setup.cfg
@@ -1,0 +1,20 @@
+[metadata]
+name = diagnosis-viewer
+version = 0.1.0
+url = https://github.com/localstack/diagnosis-viewer
+author = LocalStack Contributors
+author_email = info@localstack.cloud
+description = View the diagnostics endpoint directly in localstack
+long_description = file: README.md
+long_description_content_type = text/markdown; charset=UTF-8
+
+[options]
+zip_safe = False
+packages = find:
+install_requires =
+    localstack>=1.4
+    diapretty@git+https://github.com/silv-io/diapretty
+
+[options.entry_points]
+localstack.extensions =
+    diagnosis-viewer = diagnosis_viewer.extension:DiagnosisViewerExtension

--- a/diagnosis-viewer/setup.py
+++ b/diagnosis-viewer/setup.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env python
+from setuptools import setup
+
+setup()


### PR DESCRIPTION
This PR adds an extension that allows you to view a human-readable output of the diagnosis endpoint of your running localstack instance, based on [diapretty](https://github.com/silv-io/diapretty/).

How to test:
* pull the branch
* cd into the extension and run `make install`
* run `localstack extensions dev enable .`
* start localstack with `EXTENSION_DEV_MODE=1` and `DEBUG=1` (to enable the diagnose endpoint)
* navigate to http://localhost:4566/diapretty
* enjoy 
![image](https://user-images.githubusercontent.com/3996682/230716765-8e8b9b1b-dece-42ac-b763-92e81cdefd94.png)



Requires
* https://github.com/silv-io/diapretty/pull/5
