### PR TITLE
Simplify aws-replicator proxy and reuse botocore client request logic

### DIFF
--- a/.github/workflows/aws-replicator.yml
+++ b/.github/workflows/aws-replicator.yml
@@ -65,7 +65,16 @@ jobs:
           cd aws-replicator
           make lint
 
-      - name: Run test
+      - name: Run integration tests
+        env:
+          AWS_DEFAULT_REGION: us-east-1
+          AWS_ACCESS_KEY_ID: ${{ secrets.TEST_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.TEST_AWS_SECRET_ACCESS_KEY }}
+        run: |
+          cd aws-replicator
+          make test
+
+      - name: Deploy and test sample app
         env:
           AWS_DEFAULT_REGION: us-east-1
           AWS_ACCESS_KEY_ID: ${{ secrets.TEST_AWS_ACCESS_KEY_ID }}

--- a/aws-replicator/Makefile
+++ b/aws-replicator/Makefile
@@ -7,6 +7,10 @@ lint:            ## Run code linter to check code style
 format:          ## Run black and isort code formatter
 	python -m isort . ; python -m black .
 
+test:            ## Run unit and integration tests
+	which pytest || pip install -e .[test]
+	pytest tests
+
 entrypoints:
 	python setup.py egg_info
 

--- a/aws-replicator/aws_replicator/client/auth_proxy.py
+++ b/aws-replicator/aws_replicator/client/auth_proxy.py
@@ -1,6 +1,6 @@
 import logging
 import re
-from typing import Optional, Tuple
+from typing import Dict, Optional, Tuple
 
 import boto3
 import requests
@@ -10,10 +10,13 @@ from localstack.aws.api import HttpRequest
 from localstack.aws.protocol.parser import create_parser
 from localstack.aws.spec import load_service
 from localstack.config import get_edge_url
+from localstack.constants import AWS_REGION_US_EAST_1
 from localstack.services.generic_proxy import ProxyListener, start_proxy_server
 from localstack.utils.bootstrap import setup_logging
+from localstack.utils.functions import run_safe
 from localstack.utils.net import get_free_tcp_port
-from localstack.utils.strings import truncate
+from localstack.utils.serving import Server
+from localstack.utils.strings import to_str, truncate
 
 from aws_replicator.client.utils import truncate_content
 from aws_replicator.config import HANDLER_PATH_PROXIES
@@ -22,16 +25,16 @@ from aws_replicator.shared.models import AddProxyRequest, ProxyConfig
 LOG = logging.getLogger(__name__)
 
 
-class AuthProxyAWS:
+class AuthProxyAWS(Server):
     def __init__(self, config: ProxyConfig):
         self.config = config
+        super().__init__(port=get_free_tcp_port())
 
-    def start(self):
+    def do_run(self):
         class Handler(ProxyListener):
             def forward_request(_self, method, path, data, headers):
                 return self.proxy_request(method, path, data, headers)
 
-        self.port = get_free_tcp_port()
         self.register_in_instance()
         # TODO: change to using Gateway!
         proxy = start_proxy_server(self.port, update_listener=Handler())
@@ -50,10 +53,6 @@ class AuthProxyAWS:
             method,
             path,
         )
-
-        # TODO remove?
-        # make sure to un-escape path entries, as otherwise this may break, e.g., S3 requests
-        # path = unquote(path)
 
         path, _, query_string = path.partition("?")
         request = HttpRequest(
@@ -74,13 +73,16 @@ class AuthProxyAWS:
             request, service_name, region_name=region_name, client=client
         )
 
-        headers_truncated = {k: truncate(v) for k, v in dict(aws_request.headers).items()}
+        # adjust request dict and fix certain edge cases in the request
+        self._adjust_request_dict(request_dict)
+
+        headers_truncated = {k: truncate(to_str(v)) for k, v in dict(aws_request.headers).items()}
         LOG.debug(
             "Sending request for service %s to AWS: %s %s - %s - %s",
             service_name,
             method,
             aws_request.url,
-            truncate_content(aws_request.body, max_length=500),
+            truncate_content(request_dict.get("body"), max_length=500),
             headers_truncated,
         )
         try:
@@ -104,81 +106,6 @@ class AuthProxyAWS:
             LOG.debug("Error when making request to AWS service %s: %s", service_name, e)
             return 400
 
-    # TODO remove
-    # def proxy_request(self, method, path, data, headers):
-    #     parsed = self._extract_region_and_service(headers)
-    #     if not parsed:
-    #         return 400
-    #     region_name, service_name = parsed
-    #
-    #     LOG.debug(
-    #         "Proxying request to %s (%s): %s %s",
-    #         service_name,
-    #         region_name,
-    #         method,
-    #         path,
-    #     )
-    #
-    #     # make sure to un-escape path entries, as otherwise this may break, e.g., S3 requests
-    #     path = unquote(path)  # unquote path
-    #
-    #     path, _, query_string = path.partition("?")
-    #     request = HttpRequest(
-    #         body=data,
-    #         method=method,
-    #         headers=headers,
-    #         path=path,
-    #         query_string=query_string,
-    #     )
-    #     session = boto3.Session()
-    #     client = session.client(service_name, region_name=region_name)
-    #
-    #     # fix headers (e.g., "Host") and create client
-    #     self._fix_headers(request, service_name)
-    #
-    #     # create signed request
-    #     aws_request, signing_region = self._parse_aws_request(
-    #         request, service_name, region_name=region_name, client=client
-    #     )
-    #     headers = {k: to_str(v) for k, v in aws_request.headers.items()}
-    #     # need to convert from AWSPreparedRequest to AWSRequest, as this is what add_auth(..) expects
-    #     aws_request = AWSRequest(
-    #         method=method, headers=headers, url=aws_request.url, data=aws_request.body
-    #     )
-    #     credentials = session.get_credentials()
-    #     signer = SigV4Auth(credentials, service_name, region_name=signing_region)
-    #     signer.add_auth(aws_request)
-    #
-    #     url = aws_request.url
-    #
-    #     headers_truncated = {k: truncate(v) for k, v in dict(aws_request.headers).items()}
-    #     LOG.debug(
-    #         "Sending request for service %s to AWS: %s %s - %s - %s",
-    #         service_name,
-    #         method,
-    #         url,
-    #         truncate_content(aws_request.data, max_length=500),
-    #         # headers_truncated, # TODO
-    #         dict(aws_request.headers),
-    #     )
-    #     try:
-    #         # client._endpoint._send_request(request_dict, operation_model)
-    #
-    #         # send request to upstream AWS
-    #         response = requests.request(
-    #             method=method, url=url, data=aws_request.data, headers=aws_request.headers
-    #         )
-    #         LOG.debug(
-    #             "Received response for service %s from AWS: %s - %s",
-    #             service_name,
-    #             response.status_code,
-    #             truncate_content(response.content, max_length=500),
-    #         )
-    #         return response
-    #     except Exception as e:
-    #         LOG.debug("Error when making request to AWS service %s: %s", service_name, e)
-    #         return 400
-
     def register_in_instance(self):
         port = getattr(self, "port", None)
         if not port:
@@ -197,7 +124,7 @@ class AuthProxyAWS:
 
     def _parse_aws_request(
         self, request: HttpRequest, service_name: str, region_name: str, client
-    ) -> Tuple[OperationModel, AWSPreparedRequest, str]:
+    ) -> Tuple[OperationModel, AWSPreparedRequest, Dict]:
         parser = create_parser(load_service(service_name))
         operation_model, parsed_request = parser.parse(request)
         request_context = {
@@ -224,49 +151,23 @@ class AuthProxyAWS:
 
         return operation_model, aws_request, request_dict
 
-    # TODO remove
-    # def _parse_aws_request(
-    #     self, request: HttpRequest, service_name: str, region_name: str, client
-    # ) -> Tuple[AWSPreparedRequest, str]:
-    #     parser = create_parser(load_service(service_name))
-    #     operation_model, parsed_request = parser.parse(request)
-    #     request_context = {
-    #         "client_region": region_name,
-    #         "has_streaming_input": operation_model.has_streaming_input,
-    #         "auth_type": operation_model.auth_type,
-    #         "client_config": client.meta.config,
-    #     }
-    #     print("!!config", client.meta.config.__dict__)
-    #     parsed_request = {} if parsed_request is None else parsed_request
-    #     parsed_request = {k: v for k, v in parsed_request.items() if v is not None}
-    #     endpoint_url, additional_headers = client._resolve_endpoint_ruleset(
-    #         operation_model, parsed_request, request_context
-    #     )
-    #     print("!!endpoint_url", endpoint_url, parsed_request, request_context)
-    #     request_dict = client._convert_to_request_dict(
-    #         parsed_request,
-    #         operation_model,
-    #         endpoint_url=endpoint_url,
-    #         context=request_context,
-    #         headers=additional_headers,
-    #     )
-    #     print("!!request_dict", request_dict)
-    #     aws_request = client._endpoint.create_request(request_dict, operation_model)
-    #
-    #     result = client._endpoint.make_request(operation_model, request_dict)
-    #     print("!!!!!RESULT", result)
-    #
-    #     if request_dict.get("body"):
-    #         # overwrite request data, to avoid divergence in Content-Length (e.g., in case of JSON
-    #         # formatting with/without whitespaces) and hence invalid request signatures
-    #         aws_request.body = request_dict["body"]
-    #     signing_region = (
-    #         request_dict.get("context", {}).get("signing", {}).get("region") or region_name
-    #     )
-    #
-    #     return aws_request, signing_region
+    def _adjust_request_dict(self, request_dict: Dict):
+        """Apply minor fixes to the request dict, which seem to be required in the current setup."""
 
-    def _fix_headers(self, request, service_name):
+        body_str = run_safe(lambda: to_str(request_dict["body"])) or ""
+
+        # TODO: this custom fix should not be required - investigate and remove!
+        if "<CreateBucketConfiguration" in body_str and "LocationConstraint" not in body_str:
+            region = request_dict["context"]["client_region"]
+            if region == AWS_REGION_US_EAST_1:
+                request_dict["body"] = ""
+            else:
+                request_dict["body"] = (
+                    '<CreateBucketConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">'
+                    f"<LocationConstraint>{region}</LocationConstraint></CreateBucketConfiguration>"
+                )
+
+    def _fix_headers(self, request: HttpRequest, service_name: str):
         if service_name == "s3":
             # fix the Host header, to avoid bucket addressing issues
             host = request.headers.get("Host") or ""
@@ -289,7 +190,8 @@ class AuthProxyAWS:
         return parts[2], parts[3]
 
 
-def start_aws_auth_proxy(config: ProxyConfig):
+def start_aws_auth_proxy(config: ProxyConfig) -> AuthProxyAWS:
     setup_logging()
     proxy = AuthProxyAWS(config)
     proxy.start()
+    return proxy

--- a/aws-replicator/aws_replicator/client/auth_proxy.py
+++ b/aws-replicator/aws_replicator/client/auth_proxy.py
@@ -4,8 +4,8 @@ from typing import Optional, Tuple
 
 import boto3
 import requests
-from botocore.auth import SigV4Auth
-from botocore.awsrequest import AWSRequest
+from botocore.awsrequest import AWSPreparedRequest
+from botocore.model import OperationModel
 from localstack.aws.api import HttpRequest
 from localstack.aws.protocol.parser import create_parser
 from localstack.aws.spec import load_service
@@ -13,7 +13,7 @@ from localstack.config import get_edge_url
 from localstack.services.generic_proxy import ProxyListener, start_proxy_server
 from localstack.utils.bootstrap import setup_logging
 from localstack.utils.net import get_free_tcp_port
-from localstack.utils.strings import to_str, truncate
+from localstack.utils.strings import truncate
 
 from aws_replicator.client.utils import truncate_content
 from aws_replicator.config import HANDLER_PATH_PROXIES
@@ -51,6 +51,10 @@ class AuthProxyAWS:
             path,
         )
 
+        # TODO remove?
+        # make sure to un-escape path entries, as otherwise this may break, e.g., S3 requests
+        # path = unquote(path)
+
         path, _, query_string = path.partition("?")
         request = HttpRequest(
             body=data,
@@ -65,34 +69,30 @@ class AuthProxyAWS:
         # fix headers (e.g., "Host") and create client
         self._fix_headers(request, service_name)
 
-        # create signed request
-        aws_request, signing_region = self._parse_aws_request(
-            request, service_name, region_name, client
+        # create request and request dict
+        operation_model, aws_request, request_dict = self._parse_aws_request(
+            request, service_name, region_name=region_name, client=client
         )
-        headers = {k: to_str(v) for k, v in aws_request.headers.items()}
-        # need to convert from AWSPreparedRequest to AWSRequest, as this is what add_auth(..) expects
-        aws_request = AWSRequest(
-            method=method, headers=headers, url=aws_request.url, data=aws_request.body
-        )
-        url = aws_request.url
-        credentials = session.get_credentials()
-        signer = SigV4Auth(credentials, service_name, region_name=signing_region)
-        signer.add_auth(aws_request)
 
         headers_truncated = {k: truncate(v) for k, v in dict(aws_request.headers).items()}
         LOG.debug(
             "Sending request for service %s to AWS: %s %s - %s - %s",
             service_name,
             method,
-            url,
-            truncate_content(data, max_length=500),
+            aws_request.url,
+            truncate_content(aws_request.body, max_length=500),
             headers_truncated,
         )
         try:
             # send request to upstream AWS
-            response = requests.request(
-                method=method, url=url, data=aws_request.data, headers=aws_request.headers
-            )
+            result = client._endpoint.make_request(operation_model, request_dict)
+
+            # create response object
+            response = requests.Response()
+            response.status_code = result[0].status_code
+            response._content = result[0].content
+            response.headers = dict(result[0].headers)
+
             LOG.debug(
                 "Received response for service %s from AWS: %s - %s",
                 service_name,
@@ -103,6 +103,81 @@ class AuthProxyAWS:
         except Exception as e:
             LOG.debug("Error when making request to AWS service %s: %s", service_name, e)
             return 400
+
+    # TODO remove
+    # def proxy_request(self, method, path, data, headers):
+    #     parsed = self._extract_region_and_service(headers)
+    #     if not parsed:
+    #         return 400
+    #     region_name, service_name = parsed
+    #
+    #     LOG.debug(
+    #         "Proxying request to %s (%s): %s %s",
+    #         service_name,
+    #         region_name,
+    #         method,
+    #         path,
+    #     )
+    #
+    #     # make sure to un-escape path entries, as otherwise this may break, e.g., S3 requests
+    #     path = unquote(path)  # unquote path
+    #
+    #     path, _, query_string = path.partition("?")
+    #     request = HttpRequest(
+    #         body=data,
+    #         method=method,
+    #         headers=headers,
+    #         path=path,
+    #         query_string=query_string,
+    #     )
+    #     session = boto3.Session()
+    #     client = session.client(service_name, region_name=region_name)
+    #
+    #     # fix headers (e.g., "Host") and create client
+    #     self._fix_headers(request, service_name)
+    #
+    #     # create signed request
+    #     aws_request, signing_region = self._parse_aws_request(
+    #         request, service_name, region_name=region_name, client=client
+    #     )
+    #     headers = {k: to_str(v) for k, v in aws_request.headers.items()}
+    #     # need to convert from AWSPreparedRequest to AWSRequest, as this is what add_auth(..) expects
+    #     aws_request = AWSRequest(
+    #         method=method, headers=headers, url=aws_request.url, data=aws_request.body
+    #     )
+    #     credentials = session.get_credentials()
+    #     signer = SigV4Auth(credentials, service_name, region_name=signing_region)
+    #     signer.add_auth(aws_request)
+    #
+    #     url = aws_request.url
+    #
+    #     headers_truncated = {k: truncate(v) for k, v in dict(aws_request.headers).items()}
+    #     LOG.debug(
+    #         "Sending request for service %s to AWS: %s %s - %s - %s",
+    #         service_name,
+    #         method,
+    #         url,
+    #         truncate_content(aws_request.data, max_length=500),
+    #         # headers_truncated, # TODO
+    #         dict(aws_request.headers),
+    #     )
+    #     try:
+    #         # client._endpoint._send_request(request_dict, operation_model)
+    #
+    #         # send request to upstream AWS
+    #         response = requests.request(
+    #             method=method, url=url, data=aws_request.data, headers=aws_request.headers
+    #         )
+    #         LOG.debug(
+    #             "Received response for service %s from AWS: %s - %s",
+    #             service_name,
+    #             response.status_code,
+    #             truncate_content(response.content, max_length=500),
+    #         )
+    #         return response
+    #     except Exception as e:
+    #         LOG.debug("Error when making request to AWS service %s: %s", service_name, e)
+    #         return 400
 
     def register_in_instance(self):
         port = getattr(self, "port", None)
@@ -120,37 +195,76 @@ class AuthProxyAWS:
             )
             raise
 
-    def _parse_aws_request(self, request: HttpRequest, service_name: str, region_name: str, client):
+    def _parse_aws_request(
+        self, request: HttpRequest, service_name: str, region_name: str, client
+    ) -> Tuple[OperationModel, AWSPreparedRequest, str]:
         parser = create_parser(load_service(service_name))
         operation_model, parsed_request = parser.parse(request)
         request_context = {
             "client_region": region_name,
             "has_streaming_input": operation_model.has_streaming_input,
             "auth_type": operation_model.auth_type,
+            "client_config": client.meta.config,
         }
         parsed_request = {} if parsed_request is None else parsed_request
         parsed_request = {k: v for k, v in parsed_request.items() if v is not None}
         endpoint_url, additional_headers = client._resolve_endpoint_ruleset(
             operation_model, parsed_request, request_context
         )
+
+        # create request dict
         request_dict = client._convert_to_request_dict(
             parsed_request,
             operation_model,
-            endpoint_url,
+            endpoint_url=endpoint_url,
             context=request_context,
             headers=additional_headers,
         )
         aws_request = client._endpoint.create_request(request_dict, operation_model)
 
-        if request_dict.get("body"):
-            # overwrite request data, to avoid divergence in Content-Length (e.g., in case of JSON
-            # formatting with/without whitespaces) and hence invalid request signatures
-            aws_request.body = request_dict["body"]
-        signing_region = (
-            request_dict.get("context", {}).get("signing", {}).get("region") or region_name
-        )
+        return operation_model, aws_request, request_dict
 
-        return aws_request, signing_region
+    # TODO remove
+    # def _parse_aws_request(
+    #     self, request: HttpRequest, service_name: str, region_name: str, client
+    # ) -> Tuple[AWSPreparedRequest, str]:
+    #     parser = create_parser(load_service(service_name))
+    #     operation_model, parsed_request = parser.parse(request)
+    #     request_context = {
+    #         "client_region": region_name,
+    #         "has_streaming_input": operation_model.has_streaming_input,
+    #         "auth_type": operation_model.auth_type,
+    #         "client_config": client.meta.config,
+    #     }
+    #     print("!!config", client.meta.config.__dict__)
+    #     parsed_request = {} if parsed_request is None else parsed_request
+    #     parsed_request = {k: v for k, v in parsed_request.items() if v is not None}
+    #     endpoint_url, additional_headers = client._resolve_endpoint_ruleset(
+    #         operation_model, parsed_request, request_context
+    #     )
+    #     print("!!endpoint_url", endpoint_url, parsed_request, request_context)
+    #     request_dict = client._convert_to_request_dict(
+    #         parsed_request,
+    #         operation_model,
+    #         endpoint_url=endpoint_url,
+    #         context=request_context,
+    #         headers=additional_headers,
+    #     )
+    #     print("!!request_dict", request_dict)
+    #     aws_request = client._endpoint.create_request(request_dict, operation_model)
+    #
+    #     result = client._endpoint.make_request(operation_model, request_dict)
+    #     print("!!!!!RESULT", result)
+    #
+    #     if request_dict.get("body"):
+    #         # overwrite request data, to avoid divergence in Content-Length (e.g., in case of JSON
+    #         # formatting with/without whitespaces) and hence invalid request signatures
+    #         aws_request.body = request_dict["body"]
+    #     signing_region = (
+    #         request_dict.get("context", {}).get("signing", {}).get("region") or region_name
+    #     )
+    #
+    #     return aws_request, signing_region
 
     def _fix_headers(self, request, service_name):
         if service_name == "s3":

--- a/aws-replicator/aws_replicator/client/cli.py
+++ b/aws-replicator/aws_replicator/client/cli.py
@@ -51,7 +51,8 @@ def cmd_aws_proxy(services: str, config: str):
         for service in services:
             config_json["services"][service] = ProxyServiceConfig(resources=".*")
     try:
-        start_aws_auth_proxy(config_json)
+        proxy = start_aws_auth_proxy(config_json)
+        proxy.join()
     except Exception as e:
         console.print("Unable to start and register auth proxy: %s" % e)
         sys.exit(1)

--- a/aws-replicator/aws_replicator/server/aws_request_forwarder.py
+++ b/aws-replicator/aws_replicator/server/aws_request_forwarder.py
@@ -12,6 +12,7 @@ from localstack.http import Response
 from localstack.utils.aws import arns
 from localstack.utils.aws.aws_stack import get_valid_regions, mock_aws_request_headers
 from localstack.utils.collections import ensure_list
+from localstack.utils.strings import to_str
 from requests.structures import CaseInsensitiveDict
 
 from aws_replicator.shared.models import ProxyInstance
@@ -95,7 +96,7 @@ class AwsProxyHandler(Handler):
         port = proxy["port"]
         request = context.request
         target_host = config.DOCKER_HOST_FROM_CONTAINER if config.is_in_docker else LOCALHOST
-        url = f"http://{target_host}:{port}{request.path}"
+        url = f"http://{target_host}:{port}{request.path}?{to_str(request.query_string)}"
 
         # inject Auth header, to ensure we're passing the right region to the proxy (e.g., for Cognito InitiateAuth)
         self._extract_region_from_domain(context)

--- a/aws-replicator/aws_replicator/server/aws_request_forwarder.py
+++ b/aws-replicator/aws_replicator/server/aws_request_forwarder.py
@@ -46,9 +46,13 @@ class AwsProxyHandler(Handler):
 
     def select_proxy(self, context: RequestContext) -> Optional[ProxyInstance]:
         """select a proxy responsible to forward a request to real AWS"""
-        for port, proxy in self.PROXY_INSTANCES.items():
-            proxy_config = proxy["config"]
-            service_config = proxy_config["services"].get(context.service.service_name)
+        # reverse the list, to start with more recently added proxies first ...
+        proxy_ports = reversed(self.PROXY_INSTANCES.keys())
+        for port in proxy_ports:
+            proxy = self.PROXY_INSTANCES[port]
+            proxy_config = proxy.get("config") or {}
+            services = proxy_config.get("services") or {}
+            service_config = services.get(context.service.service_name)
             if not service_config:
                 continue
 

--- a/aws-replicator/setup.cfg
+++ b/aws-replicator/setup.cfg
@@ -23,6 +23,13 @@ install_requires =
     quart
     werkzeug
 
+[options.extras_require]
+test =
+    apispec
+    openapi-spec-validator
+    pytest
+    pytest-httpserver
+
 [options.entry_points]
 localstack.extensions =
     aws-replicator = aws_replicator.server.extension:AwsReplicatorExtension

--- a/aws-replicator/tests/conftest.py
+++ b/aws-replicator/tests/conftest.py
@@ -1,0 +1,21 @@
+import pytest
+from localstack.testing.aws.util import base_aws_client, base_aws_client_factory, base_aws_session
+
+pytest_plugins = [
+    "localstack.testing.pytest.fixtures",
+]
+
+
+@pytest.fixture(scope="session")
+def aws_session():
+    return base_aws_session()
+
+
+@pytest.fixture(scope="session")
+def aws_client_factory(aws_session):
+    return base_aws_client_factory(aws_session)
+
+
+@pytest.fixture(scope="session")
+def aws_client(aws_client_factory):
+    return base_aws_client(aws_client_factory)

--- a/aws-replicator/tests/test_extension.py
+++ b/aws-replicator/tests/test_extension.py
@@ -1,0 +1,57 @@
+# Note: these tests depend on the extension being installed and actual AWS credentials being configured, such
+# that the proxy can be started within the tests. They are designed to be mostly run in CI at this point.
+
+import boto3
+import pytest
+from botocore.exceptions import ClientError
+from localstack.aws.connect import connect_to
+from localstack.utils.net import wait_for_port_open
+
+from aws_replicator.client.auth_proxy import start_aws_auth_proxy
+from aws_replicator.shared.models import ProxyConfig
+
+
+@pytest.fixture
+def start_aws_proxy():
+    proxies = []
+
+    def _start(config: dict = None):
+        proxy = start_aws_auth_proxy(config)
+        wait_for_port_open(proxy.port)
+        proxies.append(proxy)
+        return proxy
+
+    yield _start
+
+    for proxy in proxies:
+        proxy.shutdown()
+
+
+def test_s3_requests(start_aws_proxy, s3_create_bucket):
+    # start proxy
+    config = ProxyConfig(services={"s3": {"resources": ".*"}})
+    start_aws_proxy(config)
+
+    # create clients
+    s3_client = connect_to().s3
+    s3_client_aws = boto3.client("s3")
+
+    # create bucket
+    bucket = s3_create_bucket()
+    buckets = s3_client.list_buckets()["Buckets"]
+    bucket_aws = s3_client_aws.list_buckets()["Buckets"]
+    assert buckets == bucket_aws
+
+    # put object
+    key = "test-key-with-urlencoded-chars-:+"
+    s3_client.put_object(Bucket=bucket, Key=key, Body=b"test 123")
+
+    # get object
+    result = s3_client.get_object(Bucket=bucket, Key=key)
+    assert result["Body"].read() == b"test 123"
+
+    # delete object
+    s3_client.delete_object(Bucket=bucket, Key=key)
+    with pytest.raises(ClientError) as exc:
+        s3_client.get_object(Bucket=bucket, Key=key)
+    exc.match("does not exist")


### PR DESCRIPTION
This PR simplifies the aws-replicator proxy and reuses some of the botocore client request logic.

The starting point for this change was some signature issues (403 errors) that happened when requesting S3 objects with (although the corresponding non-proxied plain `aws` commands were working properly).
```
$ awslocal s3 --debug cp s3://my-test-bucket/serverless/localstack-demo/aws/1666271273300-2022-10-20T13:07:53.300Z/localstack-demo.zip /tmp/foo.zip
...
  File "/Users/whummer/.pyenv/versions/3.10.4/lib/python3.10/site-packages/botocore/client.py", line 960, in _make_api_call
    raise error_class(parsed_response, operation_name)
botocore.exceptions.ClientError: An error occurred (403) when calling the HeadObject operation: Forbidden
```

It turns out that we can simplify the logic - instead of running requests manually using the `requests` library, we can simply use botocore's `Endpoint.make_request(..)` method (which is simpler, and will handle edge cases for us automatically).