### PR TITLE
Further enhance parity in AWS replicator proxy

### DIFF
--- a/aws-replicator/aws_replicator/client/auth_proxy.py
+++ b/aws-replicator/aws_replicator/client/auth_proxy.py
@@ -140,11 +140,12 @@ class AuthProxyAWS(Server):
         )
 
         # TODO: fix for switch between path/host addressing - seems to be causing issues in CI, to be investigated!
-        path_parts = request.path.strip("/").split("/")
-        if service_name == "s3" and endpoint_url:
-            bucket_subdomain_prefix = f"//{path_parts[0]}.s3."
-            if path_parts and bucket_subdomain_prefix in endpoint_url:
-                endpoint_url = endpoint_url.replace(bucket_subdomain_prefix, "//s3.")
+        # TODO: still required?
+        # path_parts = request.path.strip("/").split("/")
+        # if service_name == "s3" and endpoint_url:
+        #     bucket_subdomain_prefix = f"://{path_parts[0]}.s3."
+        #     if path_parts and bucket_subdomain_prefix in endpoint_url:
+        #         endpoint_url = endpoint_url.replace(bucket_subdomain_prefix, "//s3.")
 
         # create request dict
         request_dict = client._convert_to_request_dict(

--- a/aws-replicator/aws_replicator/client/auth_proxy.py
+++ b/aws-replicator/aws_replicator/client/auth_proxy.py
@@ -162,6 +162,9 @@ class AuthProxyAWS(Server):
                 request_dict["url_path"] = request_dict["url_path"].removeprefix(
                     f"/{path_parts[0]}"
                 )
+                if not request_dict["url_path"]:
+                    request_dict["url_path"] = "/"
+                    request_dict["url"] += "/"
 
         aws_request = client._endpoint.create_request(request_dict, operation_model)
 

--- a/aws-replicator/aws_replicator/server/aws_request_forwarder.py
+++ b/aws-replicator/aws_replicator/server/aws_request_forwarder.py
@@ -34,9 +34,6 @@ class AwsProxyHandler(Handler):
 
         if response is None:
             return
-        if response.status_code == 404:
-            # TODO: make this fallback configurable?
-            return
 
         # set response details, then stop handler chain to return response
         chain.response.data = response.raw_content

--- a/aws-replicator/setup.cfg
+++ b/aws-replicator/setup.cfg
@@ -10,6 +10,10 @@ author_email = info@localstack.cloud
 zip_safe = False
 packages = find:
 install_requires =
+    # TODO: currently requires a version pin, see note in auth_proxy.py
+    boto3>=1.26.151
+    # TODO: currently requires a version pin, see note in auth_proxy.py
+    botocore>=1.29.151
     flask
     localstack>=1.0.0
     xmltodict

--- a/aws-replicator/tests/test_extension.py
+++ b/aws-replicator/tests/test_extension.py
@@ -7,6 +7,7 @@ import pytest
 from botocore.exceptions import ClientError
 from localstack.aws.connect import connect_to
 from localstack.utils.net import wait_for_port_open
+from localstack.utils.sync import retry
 
 from aws_replicator.client.auth_proxy import start_aws_auth_proxy
 from aws_replicator.shared.models import ProxyConfig
@@ -75,8 +76,13 @@ def test_s3_requests(start_aws_proxy, s3_create_bucket, metadata_gzip):
 
     # delete bucket
     s3_client_aws.delete_bucket(Bucket=bucket)
-    with pytest.raises(ClientError) as aws_exc:
-        s3_client_aws.head_bucket(Bucket=bucket)
-    with pytest.raises(ClientError) as exc:
-        s3_client.head_bucket(Bucket=bucket)
-    assert str(exc.value) == str(aws_exc.value)
+
+    def _assert_deleted():
+        with pytest.raises(ClientError) as aws_exc:
+            s3_client_aws.head_bucket(Bucket=bucket)
+        with pytest.raises(ClientError) as exc:
+            s3_client.head_bucket(Bucket=bucket)
+        assert str(exc.value) == str(aws_exc.value)
+
+    # run asynchronously, as apparently this can take some time
+    retry(_assert_deleted, retries=3, sleep=5)

--- a/aws-replicator/tests/test_extension.py
+++ b/aws-replicator/tests/test_extension.py
@@ -67,6 +67,16 @@ def test_s3_requests(start_aws_proxy, s3_create_bucket, metadata_gzip):
 
     # delete object
     s3_client.delete_object(Bucket=bucket, Key=key)
+    with pytest.raises(ClientError) as aws_exc:
+        s3_client_aws.get_object(Bucket=bucket, Key=key)
     with pytest.raises(ClientError) as exc:
         s3_client.get_object(Bucket=bucket, Key=key)
-    exc.match("does not exist")
+    assert str(exc.value) == str(aws_exc.value)
+
+    # delete bucket
+    s3_client_aws.delete_bucket(Bucket=bucket)
+    with pytest.raises(ClientError) as aws_exc:
+        s3_client_aws.head_bucket(Bucket=bucket)
+    with pytest.raises(ClientError) as exc:
+        s3_client.head_bucket(Bucket=bucket)
+    assert str(exc.value) == str(aws_exc.value)


### PR DESCRIPTION
Further enhance parity in AWS replicator proxy. Based on feedback we've received from one of our beta users.

* remove `status_code == 404` check, which was causing issues with processing upstream responses
* extend the tests to assert correct error responses and full parity with real AWS
* adjust the fixes around patches for `request_dict` - the behavior seems to be different across `botocore` versions. Seems to be working with 1.29.97 whereas newer versions like 1.29.151 require this fix, to avoid duplicate bucket encodings in the URL like `https://mybucket.s3.amazonaws.com/mybucket`