### PR TITLE
Use urlunparse instead of manual URL string operations in AWS proxy

### DIFF
--- a/aws-replicator/README.md
+++ b/aws-replicator/README.md
@@ -13,7 +13,7 @@ A LocalStack extension to replicate AWS resources into your local machine.
 
 ## Overview
 
-This extension currently offers two modes of operation - (1) the AWS connection proxy, and (2) the resource replicator CLI.
+This extension currently offers two modes of operation: (1) the AWS connection proxy, and (2) the resource replicator CLI.
 
 ## AWS Connection Proxy
 

--- a/aws-replicator/tests/test_config.py
+++ b/aws-replicator/tests/test_config.py
@@ -1,0 +1,13 @@
+from aws_replicator.server.aws_request_forwarder import AwsProxyHandler
+from aws_replicator.shared.models import ProxyServiceConfig
+
+
+def test_get_resource_names():
+    service_config = ProxyServiceConfig(resources="")
+    assert AwsProxyHandler._get_resource_names(service_config) == [".*"]
+
+    service_config = ProxyServiceConfig(resources="foobar")
+    assert AwsProxyHandler._get_resource_names(service_config) == ["foobar"]
+
+    service_config = ProxyServiceConfig(resources=["foo", "bar"])
+    assert AwsProxyHandler._get_resource_names(service_config) == ["foo", "bar"]

--- a/aws-replicator/tests/test_extension.py
+++ b/aws-replicator/tests/test_extension.py
@@ -66,6 +66,17 @@ def test_s3_requests(start_aws_proxy, s3_create_bucket, metadata_gzip):
     result_body_aws = result["Body"].read()
     assert result_body_proxied == result_body_aws
 
+    for kwargs in [{}, {"Delimiter": "/"}]:
+        # list objects
+        result_aws = s3_client_aws.list_objects(Bucket=bucket, **kwargs)
+        result_proxied = s3_client.list_objects(Bucket=bucket, **kwargs)
+        assert result_proxied["Contents"] == result_aws["Contents"]
+
+        # list objects v2
+        result_aws = s3_client_aws.list_objects_v2(Bucket=bucket, **kwargs)
+        result_proxied = s3_client.list_objects_v2(Bucket=bucket, **kwargs)
+        assert result_proxied["Contents"] == result_aws["Contents"]
+
     # delete object
     s3_client.delete_object(Bucket=bucket, Key=key)
     with pytest.raises(ClientError) as aws_exc:


### PR DESCRIPTION
* use `urlunparse` instead of manual URL string operations in AWS proxy
* extend tests to also cover S3 `list_objects` and `list_objects_v2`