### PR TITLE
minor: Use latest dev release of CLI for testing

### DIFF
--- a/.github/workflows/aws-replicator.yml
+++ b/.github/workflows/aws-replicator.yml
@@ -13,7 +13,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  tests-miniflare:
+  tests-aws-proxy:
     name: Run extension tests
     runs-on: ubuntu-latest
     steps:
@@ -34,7 +34,8 @@ jobs:
         run: |
           docker pull localstack/localstack-pro &
           docker pull public.ecr.aws/lambda/python:3.8 &
-          pip install localstack localstack-ext
+          # install latest CLI packages (dev releases)
+          pip install --upgrade --pre localstack localstack-ext
 
           # TODO remove
           mkdir ~/.localstack; echo '{"token":"test"}' > ~/.localstack/auth.json

--- a/aws-replicator/aws_replicator/client/service_states.py
+++ b/aws-replicator/aws_replicator/client/service_states.py
@@ -75,9 +75,9 @@ class StateReplicatorSQSQueue(ExtendedResourceStateReplicator):
 
 # @mixin_for(DynamoDBTable)
 class StateReplicatorDynamoDBTable(ExtendedResourceStateReplicator):
-    @classmethod
-    def cloudformation_type(cls):
-        return "AWS::DynamoDB::Table"
+    # @classmethod
+    # def cloudformation_type(cls):
+    #     return "AWS::DynamoDB::Table"
 
     def add_extended_state_external(self, remote_client: BaseClient = None):
         table_name = self.props["TableName"]


### PR DESCRIPTION
Use latest dev release of CLI for testing. This is to test/debug a recent issue with S3 proxying that has been reported by a user.