### PR TITLE
fix failing integration tests

### DIFF
--- a/aws-replicator/tests/conftest.py
+++ b/aws-replicator/tests/conftest.py
@@ -1,5 +1,5 @@
 import pytest
-from localstack.testing.aws.util import base_aws_client, base_aws_client_factory, base_aws_session
+from localstack.testing.aws.util import primary_testing_aws_client, base_aws_client_factory, base_aws_session
 
 pytest_plugins = [
     "localstack.testing.pytest.fixtures",
@@ -18,4 +18,4 @@ def aws_client_factory(aws_session):
 
 @pytest.fixture(scope="session")
 def aws_client(aws_client_factory):
-    return base_aws_client(aws_client_factory)
+    return primary_testing_aws_client(aws_client_factory)


### PR DESCRIPTION
Currently the integration tests for aws-replicator extension is failing. 

The issue is related to the `client` change in the community repo: https://github.com/localstack/localstack/pull/8520
particularly in `localstack/testing/aws/util.py`. 