### PR TITLE
add mailhog extension

### DIFF
--- a/mailhog/Makefile
+++ b/mailhog/Makefile
@@ -1,0 +1,39 @@
+VENV_BIN = python3 -m venv
+VENV_DIR ?= .venv
+VENV_ACTIVATE = $(VENV_DIR)/bin/activate
+VENV_RUN = . $(VENV_ACTIVATE)
+
+venv: $(VENV_ACTIVATE)
+
+$(VENV_ACTIVATE): setup.py setup.cfg
+	test -d .venv || $(VENV_BIN) .venv
+	$(VENV_RUN); pip install --upgrade pip setuptools plux
+	$(VENV_RUN); pip install --upgrade black isort pyproject-flake8 flake8-black flake8-isort
+	$(VENV_RUN); pip install -e .
+	touch $(VENV_DIR)/bin/activate
+
+clean:
+	rm -rf .venv/
+	rm -rf build/
+	rm -rf .eggs/
+	rm -rf *.egg-info/
+
+lint:              		  ## Run code linter to check code style
+	($(VENV_RUN); python -m pflake8 --show-source)
+
+format:            		  ## Run black and isort code formatter
+	$(VENV_RUN); python -m isort mailhog; python -m black mailhog
+
+install: venv
+	$(VENV_RUN); python setup.py develop
+
+dist: venv
+	$(VENV_RUN); python setup.py sdist bdist_wheel
+
+publish: clean-dist venv dist
+	$(VENV_RUN); pip install --upgrade twine; twine upload dist/*
+
+clean-dist: clean
+	rm -rf dist/
+
+.PHONY: clean clean-dist dist install publish

--- a/mailhog/README.md
+++ b/mailhog/README.md
@@ -40,6 +40,7 @@ $ awslocal ses send-email \
 ```
 
 You should see the mail arriving in MailHog.
+![Screenshot at 2023-07-26 12-08-54](https://github.com/localstack/localstack-extensions/assets/3996682/7b0bb4e5-2fc1-4f6b-a90e-0ed31663b411)
 
 
 ## Configure

--- a/mailhog/README.md
+++ b/mailhog/README.md
@@ -4,15 +4,43 @@ LocalStack Mailhog Extension
 Web and API based STMP testing directly in LocalStack using [MailHog](https://github.com/mailhog/MailHog).
 
 If the standard configuration is used, LocalStack will serve the UI through http://mailhog.localhost.localstack.cloud:4566 or http://localhost:4566/mailhog/.
-It will also configure `SMTP_HOST` automatically, which points all services using SMTP, including [SES](https://docs.localstack.cloud/user-guide/aws/ses/), to mailhog.
+It will also configure `SMTP_HOST` automatically, which points all services using SMTP, including [SES](https://docs.localstack.cloud/user-guide/aws/ses/), to MailHog.
 
 ## Install from GitHub repository
 
-To distribute your extension, simply upload it to your GitHub account. Your extension can then be installed via:
+Install the extension directly from the GitHub repository by running:
 
 ```bash
 localstack extensions install "git+https://github.com/localstack/localstack-extensions/#egg=localstack-mailhog-extension&subdirectory=mailhog"
 ```
+
+After starting LocalStack, you should see these lines in the log:
+
+```
+2023-07-26T10:00:08.072  INFO --- [  MainThread] mailhog.extension          : serving mailhog extension on host: http://mailhog.localhost.localstack.cloud:4566
+2023-07-26T10:00:08.072  INFO --- [  MainThread] mailhog.extension          : serving mailhog extension on path: http://localhost:4566/mailhog/
+```
+
+## Integration with LocalStack
+
+When using this extension, LocalStack is automatically configured to use the MailHog SMTP server when sending emails.
+For example, if you run the following SES commands:
+
+```console
+$ awslocal ses verify-email-identity --email-address user1@yourdomain.com
+```
+```
+$ awslocal ses send-email \                                              
+    --from user1@yourdomain.com \
+    --message 'Body={Text={Data="Hello from LocalStack to MailHog"}},Subject={Data=Test Email}' \
+    --destination 'ToAddresses=recipient1@example.com'
+{
+    "MessageId": "ktrmpmhohorxfbjd-dzebwdgu-odnm-wyvz-pezg-mijejwlvaxtr-psfctr"
+}
+```
+
+You should see the mail arriving in MailHog.
+
 
 ## Configure
 
@@ -20,7 +48,9 @@ You can use the [MailHog configuration environment variables](https://github.com
 When using the CLI, you can add them by using `DOCKER_FLAGS='-e MH_<var>=<val> -e ...'`.
 If you are using docker compose, simply add them as environment variables to the container.
 
-## Install local development version
+## Development
+
+### Install local development version
 
 To install the extension into localstack in developer mode, you will need Python 3.10, and create a virtual environment in the extensions project.
 
@@ -41,10 +71,6 @@ You can then start LocalStack with `EXTENSION_DEV_MODE=1` to load all enabled ex
 ```bash
 EXTENSION_DEV_MODE=1 localstack start
 ```
-
-## Licensing
-
-* MailHog is licensed under MIT license: https://github.com/mailhog/MailHog/blob/master/LICENSE.md
 
 ## Known Limitations
 
@@ -74,3 +100,8 @@ return await self.wsgi(scope, receive, send)
 File "/opt/code/localstack/.venv/lib/python3.10/site-packages/localstack/http/asgi.py", line 324, in __call__
 raise NotImplementedError("Unhandled protocol %s" % scope["type"])
 ```
+
+## Licensing
+
+* No modifications were made to MailHog, which is licensed under MIT license: https://github.com/mailhog/MailHog/blob/master/LICENSE.md
+* The extension code is licensed under Apache License Version 2.0

--- a/mailhog/README.md
+++ b/mailhog/README.md
@@ -1,0 +1,76 @@
+LocalStack Mailhog Extension
+===============================
+
+Web and API based STMP testing directly in LocalStack using [MailHog](https://github.com/mailhog/MailHog).
+
+If the standard configuration is used, LocalStack will serve the UI through http://mailhog.localhost.localstack.cloud:4566.
+It will also configure `SMTP_HOST` automatically, which points all services using SMTP, including [SES](https://docs.localstack.cloud/user-guide/aws/ses/), to mailhog.
+
+## Install from GitHub repository
+
+To distribute your extension, simply upload it to your github account. Your extension can then be installed via:
+
+```bash
+localstack extensions install "git+https://github.com/localstack/localstack-extensions/#egg=localstack-mailhog-extension&subdirectory=mailhog"
+```
+
+## Configure
+
+You can use the [MailHog configuration environment variables](https://github.com/mailhog/MailHog/blob/master/docs/CONFIG.md) to configure the extension.
+When using the CLI, you can add them by using `DOCKER_FLAGS='-e MH_<var>=<val> -e ...'`.
+If you are using docker compose, simply add them as environment variables to the container.
+
+## Install local development version
+
+To install the extension into localstack in developer mode, you will need Python 3.10, and create a virtual environment in the extensions project.
+
+In the newly generated project, simply run
+
+```bash
+make install
+```
+
+Then, to enable the extension for LocalStack, run
+
+```bash
+localstack extensions dev enable .
+```
+
+You can then start LocalStack with `EXTENSION_DEV_MODE=1` to load all enabled extensions:
+
+```bash
+EXTENSION_DEV_MODE=1 localstack start
+```
+
+## Licensing
+
+* MailHog is licensed under MIT license: https://github.com/mailhog/MailHog/blob/master/LICENSE.md
+
+## Known Limitations
+
+The MailHog UI supports real-time updates through websockets, which is currently not supported through the default `:4566` port.
+When you open the UI, you may see this error in the LocalStack logs, which is safe to ignore.
+The UI won't update automatically though, so you need to click the refresh button.
+```
+2023-07-25T18:23:12.465 ERROR --- [-functhread3] hypercorn.error            : Error in ASGI Framework
+Traceback (most recent call last):
+File "/opt/code/localstack/.venv/lib/python3.10/site-packages/hypercorn/asyncio/task_group.py", line 23, in _handle
+await app(scope, receive, send, sync_spawn, call_soon)
+File "/opt/code/localstack/.venv/lib/python3.10/site-packages/hypercorn/app_wrappers.py", line 33, in __call__
+await self.app(scope, receive, send)
+File "/opt/code/localstack/.venv/lib/python3.10/site-packages/localstack/aws/serving/asgi.py", line 67, in __call__
+return await self.wsgi(scope, receive, send)
+File "/opt/code/localstack/.venv/lib/python3.10/site-packages/localstack/http/asgi.py", line 324, in __call__
+raise NotImplementedError("Unhandled protocol %s" % scope["type"])
+NotImplementedError: Unhandled protocol websocket
+2023-07-25T18:23:12.465 ERROR --- [-functhread3] hypercorn.error            : Error in ASGI Framework
+Traceback (most recent call last):
+File "/opt/code/localstack/.venv/lib/python3.10/site-packages/hypercorn/asyncio/task_group.py", line 23, in _handle
+await app(scope, receive, send, sync_spawn, call_soon)
+File "/opt/code/localstack/.venv/lib/python3.10/site-packages/hypercorn/app_wrappers.py", line 33, in __call__
+await self.app(scope, receive, send)
+File "/opt/code/localstack/.venv/lib/python3.10/site-packages/localstack/aws/serving/asgi.py", line 67, in __call__
+return await self.wsgi(scope, receive, send)
+File "/opt/code/localstack/.venv/lib/python3.10/site-packages/localstack/http/asgi.py", line 324, in __call__
+raise NotImplementedError("Unhandled protocol %s" % scope["type"])
+```

--- a/mailhog/README.md
+++ b/mailhog/README.md
@@ -3,12 +3,12 @@ LocalStack Mailhog Extension
 
 Web and API based STMP testing directly in LocalStack using [MailHog](https://github.com/mailhog/MailHog).
 
-If the standard configuration is used, LocalStack will serve the UI through http://mailhog.localhost.localstack.cloud:4566.
+If the standard configuration is used, LocalStack will serve the UI through http://mailhog.localhost.localstack.cloud:4566 or http://localhost:4566/mailhog/.
 It will also configure `SMTP_HOST` automatically, which points all services using SMTP, including [SES](https://docs.localstack.cloud/user-guide/aws/ses/), to mailhog.
 
 ## Install from GitHub repository
 
-To distribute your extension, simply upload it to your github account. Your extension can then be installed via:
+To distribute your extension, simply upload it to your GitHub account. Your extension can then be installed via:
 
 ```bash
 localstack extensions install "git+https://github.com/localstack/localstack-extensions/#egg=localstack-mailhog-extension&subdirectory=mailhog"

--- a/mailhog/mailhog/__init__.py
+++ b/mailhog/mailhog/__init__.py
@@ -1,0 +1,1 @@
+name = "mailhog"

--- a/mailhog/mailhog/extension.py
+++ b/mailhog/mailhog/extension.py
@@ -1,0 +1,86 @@
+import os
+from typing import TYPE_CHECKING, Optional
+
+from localstack.extensions.api import Extension, http
+
+if TYPE_CHECKING:
+    from mailhog.server import MailHogServer
+
+import logging
+
+from localstack import config, constants
+from localstack_ext import config as config_ext
+
+LOG = logging.getLogger(__name__)
+
+
+class MailHogExtension(Extension):
+    """
+    MailHog extension. Uses environment-based configuration as described here:
+    https://github.com/mailhog/MailHog/blob/master/docs/CONFIG.md.
+
+    It exposes three services:
+    * The mailhog API
+    * The mailhog UI
+    * The mailhog SMTP server
+
+    The first two are served through a random port but then routed through the gateway and accessible through
+    http://mailhog.localhost.localstack.cloud:4566.
+
+    The mailhog SMTP server is configured automatically as ``SMTP_HOST``, so when you use SES, mails get
+    automatically delivered to mailhog. Neato burrito.
+    """
+
+    name = "localstack-mailhog-extension"
+
+    server: Optional["MailHogServer"]
+
+    def __init__(self):
+        self.server = None
+
+    def on_extension_load(self):
+        # TODO: logging should be configured automatically for extensions
+        if config.DEBUG:
+            level = logging.DEBUG
+        else:
+            level = logging.INFO
+        logging.getLogger("mailhog").setLevel(level=level)
+
+    def on_platform_start(self):
+        from mailhog.server import MailHogServer
+
+        self.server = MailHogServer()
+        LOG.info("starting mailhog server")
+        self.server.start()
+
+        if not config_ext.SMTP_HOST:
+            config_ext.SMTP_HOST = f"localhost:{self.server.get_smtp_port()}"
+            os.environ["SMTP_HOST"] = config_ext.SMTP_HOST
+            LOG.info("configuring SMTP host to internal mailhog smtp: %s", config_ext.SMTP_HOST)
+
+    def on_platform_ready(self):
+        # FIXME: reconcile with LOCALSTACK_HOST (cannot be "localhost:4566" because the UI requires a host
+        #  name mapping since it services resources on, e.g., localhost:4566/js, unless `MH_UI_WEB_PATH` is
+        #  used). the URL should be reachable from the host (the idea is that users get a log message they
+        #  can click on from the terminal)
+        url = f"http://mailhog.{constants.LOCALHOST_HOSTNAME}:{config.get_edge_port_http()}"
+        LOG.info("serving mailhog extension: %s", url)
+
+    def on_platform_shutdown(self):
+        if self.server:
+            self.server.shutdown()
+
+    def update_gateway_routes(self, router: http.Router[http.RouteHandler]):
+        # TODO: consider using `MH_UI_WEB_PATH`
+        endpoint = http.ProxyHandler(self.server.url)
+
+        router.add(
+            "/",
+            host="mailhog.<host>",
+            endpoint=endpoint,
+        )
+        router.add(
+            "/<path:path>",
+            host="mailhog.<host>",
+            endpoint=endpoint,
+        )

--- a/mailhog/mailhog/extension.py
+++ b/mailhog/mailhog/extension.py
@@ -25,13 +25,17 @@ class MailHogExtension(Extension):
     * The mailhog SMTP server
 
     The first two are served through a random port but then routed through the gateway and accessible through
-    http://mailhog.localhost.localstack.cloud:4566.
+    http://mailhog.localhost.localstack.cloud:4566, or http://localhost:4566/mailhog/ (note the trailing
+    slash).
 
     The mailhog SMTP server is configured automatically as ``SMTP_HOST``, so when you use SES, mails get
     automatically delivered to mailhog. Neato burrito.
     """
 
     name = "localstack-mailhog-extension"
+
+    hostname_prefix = "mailhog."
+    """Used for serving through a host rule."""
 
     server: Optional["MailHogServer"]
 
@@ -59,28 +63,45 @@ class MailHogExtension(Extension):
             LOG.info("configuring SMTP host to internal mailhog smtp: %s", config_ext.SMTP_HOST)
 
     def on_platform_ready(self):
-        # FIXME: reconcile with LOCALSTACK_HOST (cannot be "localhost:4566" because the UI requires a host
-        #  name mapping since it services resources on, e.g., localhost:4566/js, unless `MH_UI_WEB_PATH` is
-        #  used). the URL should be reachable from the host (the idea is that users get a log message they
-        #  can click on from the terminal)
-        url = f"http://mailhog.{constants.LOCALHOST_HOSTNAME}:{config.get_edge_port_http()}"
-        LOG.info("serving mailhog extension: %s", url)
+        # FIXME: reconcile with LOCALSTACK_HOST. the URL should be reachable from the host (the idea is
+        #  that users get a log message they can click on from the terminal)
+        url = f"http://{self.hostname_prefix}.{constants.LOCALHOST_HOSTNAME}:{config.get_edge_port_http()}"
+        LOG.info("serving mailhog extension on host: %s", url)
 
-    def on_platform_shutdown(self):
-        if self.server:
-            self.server.shutdown()
+        # trailing slash is important (see update_gateway_routes comment)
+        url = f"{config.get_edge_url()}/{self.server.web_path}/"
+        LOG.info("serving mailhog extension on path: %s", url)
 
     def update_gateway_routes(self, router: http.Router[http.RouteHandler]):
-        # TODO: consider using `MH_UI_WEB_PATH`
-        endpoint = http.ProxyHandler(self.server.url)
+        endpoint = http.ProxyHandler(forward_base_url=self.server.url + "/" + self.server.web_path)
 
+        # hostname aliases
         router.add(
             "/",
-            host="mailhog.<host>",
+            host=f"{self.hostname_prefix}<host>",
             endpoint=endpoint,
         )
         router.add(
             "/<path:path>",
-            host="mailhog.<host>",
+            host=f"{self.hostname_prefix}<host>",
             endpoint=endpoint,
         )
+
+        # serve through the web path. here the werkzeug default functionality of strict slashes would be
+        # useful, since the webapp needs to be accessed with a trailing slash (localhost:4566/<webpath>/)
+        # otherwise the relative urls (like `images/logo.png`) are resolved as
+        # `localhost:4566/images/login.png` which looks like an S3 access and will lead to localstack errors.
+        # alas, we disabled this for good reason, so we're stuck with telling the user to add the trailing
+        # slash.
+        router.add(
+            f"/{self.server.web_path}",
+            endpoint=endpoint,
+        )
+        router.add(
+            f"/{self.server.web_path}/<path:path>",
+            endpoint=endpoint,
+        )
+
+    def on_platform_shutdown(self):
+        if self.server:
+            self.server.shutdown()

--- a/mailhog/mailhog/package.py
+++ b/mailhog/mailhog/package.py
@@ -37,7 +37,8 @@ class MailHogPackageInstaller(GitHubReleaseInstaller):
         else:
             raise NotImplementedError(f"unknown architecture {arch}")
 
-        # should only be used in the container, but there are windows binaries, so might as well add them
+        # the extension would typically only be used in the container, so windows support is not needed,
+        # but since there are windows binaries might as well add them
         if operating_system == "windows":
             bin_file += ".exe"
 

--- a/mailhog/mailhog/package.py
+++ b/mailhog/mailhog/package.py
@@ -1,0 +1,47 @@
+"""
+Package for mailhog that downloads the mailhog binary from https://github.com/mailhog/MailHog.
+"""
+import os
+from functools import lru_cache
+
+from localstack.packages import GitHubReleaseInstaller, Package, PackageInstaller
+from localstack.utils.platform import Arch, get_arch, get_os
+
+_MAILHOG_VERSION = os.environ.get("MH_VERSION") or "v1.0.1"
+
+
+class MailHogPackage(Package):
+    def __init__(self, default_version: str = _MAILHOG_VERSION):
+        super().__init__(name="MailHog", default_version=default_version)
+
+    @lru_cache
+    def _get_installer(self, version: str) -> PackageInstaller:
+        return MailHogPackageInstaller(version)
+
+    def get_versions(self) -> list[str]:
+        return [_MAILHOG_VERSION]
+
+
+class MailHogPackageInstaller(GitHubReleaseInstaller):
+    def __init__(self, version: str):
+        super().__init__("mailhog", version, "mailhog/MailHog")
+
+    def _get_github_asset_name(self):
+        arch = get_arch()
+        operating_system = get_os()
+
+        if arch == Arch.amd64:
+            bin_file = f"MailHog_{operating_system}_amd64"
+        elif arch == Arch.arm64:
+            bin_file = f"MailHog_{operating_system}_arm"
+        else:
+            raise NotImplementedError(f"unknown architecture {arch}")
+
+        # should only be used in the container, but there are windows binaries, so might as well add them
+        if operating_system == "windows":
+            bin_file += ".exe"
+
+        return bin_file
+
+
+mailhog_package = MailHogPackage()

--- a/mailhog/mailhog/server.py
+++ b/mailhog/mailhog/server.py
@@ -1,0 +1,101 @@
+"""
+Tools to run the mailhog service.
+"""
+import logging
+import os
+
+from localstack import config
+from localstack.utils.net import get_free_tcp_port
+from localstack.utils.run import ShellCommandThread
+from localstack.utils.serving import Server
+from localstack.utils.threads import TMP_THREADS
+
+from mailhog.package import mailhog_package
+
+LOG = logging.getLogger(__name__)
+
+
+class MailHogServer(Server):
+
+    """
+    Mailhog server abstraction. Uses environment-based configuration as described here:
+    https://github.com/mailhog/MailHog/blob/master/docs/CONFIG.md.
+
+    It exposes three services:
+    * The mailhog API (random port)
+    * The mailhog UI (same port as API)
+    * The mailhog SMTP server (25)
+
+    It supports snapshot persistence by pointing the MH_MAILDIR_PATH to the asset directory.
+    """
+
+    def __init__(self, host: str = "0.0.0.0") -> None:
+        super().__init__(self._get_configured_or_random_api_port(), host)
+
+    def do_start_thread(self):
+        mailhog_package.install()
+
+        cmd = self._create_command()
+        env = self._create_env_vars()
+
+        LOG.debug("starting mailhog thread: %s, %s", cmd, env)
+
+        t = ShellCommandThread(
+            cmd,
+            env_vars=env,
+            name="mailhog",
+            log_listener=self._log_listener,
+        )
+        TMP_THREADS.append(t)
+        t.start()
+        return t
+
+    def _log_listener(self, line, **_kwargs):
+        LOG.debug(line.rstrip())
+
+    def get_ui_port(self) -> int:
+        if addr := os.getenv("MH_UI_BIND_ADDR"):
+            return int(addr.split(":")[-1])
+        return self.port
+
+    def get_smtp_port(self) -> int:
+        if addr := os.getenv("MH_SMTP_BIND_ADDR"):
+            return int(addr.split(":")[-1])
+
+        # TODO: use random port by default?
+        return 25
+
+    def _create_env_vars(self) -> dict:
+        env = {k: v for k, v in os.environ.items() if k.startswith("MH_")}
+
+        if not os.getenv("MH_STORAGE") and config.PERSISTENCE:
+            env["MH_STORAGE"] = "maildir"
+            env["MH_MAILDIR_PATH"] = env.get(
+                "MH_MAILDIR_PATH", os.path.join(config.dirs.data, "mailhog")
+            )
+
+        if not os.getenv("MH_API_BIND_ADDR"):
+            env["MH_API_BIND_ADDR"] = f"{self.host}:{self.port}"
+
+        if not os.getenv("MH_UI_BIND_ADDR"):
+            env["MH_UI_BIND_ADDR"] = f"{self.host}:{self.get_ui_port()}"
+
+        if not os.getenv("MH_SMTP_BIND_ADDR"):
+            env["MH_SMTP_BIND_ADDR"] = f"{self.host}:{self.get_smtp_port()}"
+
+        if not os.getenv("MH_HOSTNAME"):
+            # TODO: reconcile with LOCALSTACK_HOST
+            env["MH_HOSTNAME"] = "mailhog.localhost.localstack.cloud"
+
+        return env
+
+    def _create_command(self) -> list[str]:
+        cmd = [mailhog_package.get_installer().get_executable_path()]
+        return cmd
+
+    @staticmethod
+    def _get_configured_or_random_api_port() -> int:
+        if addr := os.getenv("MH_API_BIND_ADDR"):
+            return int(addr.split(":")[-1])
+
+        return get_free_tcp_port()

--- a/mailhog/pyproject.toml
+++ b/mailhog/pyproject.toml
@@ -1,0 +1,19 @@
+# LocalStack project configuration
+[build-system]
+requires = ['setuptools', 'wheel', 'plux>=1.3.1']
+build-backend = "setuptools.build_meta"
+
+[tool.black]
+line_length = 100
+include = '(mailhog/.*\.py$)'
+
+[tool.isort]
+profile = 'black'
+line_length = 100
+
+# call using pflake8
+[tool.flake8]
+max-line-length = 110
+ignore = 'E203,E266,E501,W503,F403'
+select = 'B,C,E,F,I,W,T4,B9'
+exclude = '.venv*,venv*,dist,*.egg-info,.git'

--- a/mailhog/setup.cfg
+++ b/mailhog/setup.cfg
@@ -1,0 +1,19 @@
+[metadata]
+name = localstack-mailhog-extension
+version = 0.1.0
+url = https://github.com/localstack/localstack-mailhog-extension
+author = LocalStack
+author_email = info@localstack.cloud
+description = Web and API based STMP testing directly in LocalStack
+long_description = file: README.md
+long_description_content_type = text/markdown; charset=UTF-8
+
+[options]
+zip_safe = False
+packages = find:
+install_requires =
+    localstack>=2.2
+
+[options.entry_points]
+localstack.extensions =
+    localstack-mailhog-extension = mailhog.extension:MailHogExtension

--- a/mailhog/setup.py
+++ b/mailhog/setup.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env python
+from setuptools import setup
+
+setup()


### PR DESCRIPTION
This PR adds an extension that packages mailhog. It consists of

* A package to download the mailhog binary from github
* A `Server` implementation around the binary
* An `Extension` implementation that starts the server and exposes it through the edge port

The extension also automatically configures `SMTP_HOST`, so when you install the extension, SES automatically sends mails to mailhog.

![Screenshot at 2023-07-25 20-46-17](https://github.com/localstack/localstack-extensions/assets/3996682/b5ef685e-534d-4313-9257-625cea7f0a2b)

## How to test

* install extension in dev mode as described in the [README](https://github.com/localstack/localstack-extensions/blob/mailhog-extension/mailhog/README.md)
* run the [SES example commands](https://docs.localstack.cloud/user-guide/aws/ses/#smtp-integration)
* open http://mailhog.localhost.localstack.cloud:4566 or http://localhost:4566/mailhog/ 
