### PR TITLE
rename hello-world extension to allow proper name matching

### DIFF
--- a/hello-world/Makefile
+++ b/hello-world/Makefile
@@ -1,0 +1,39 @@
+VENV_BIN = python3 -m venv
+VENV_DIR ?= .venv
+VENV_ACTIVATE = $(VENV_DIR)/bin/activate
+VENV_RUN = . $(VENV_ACTIVATE)
+
+venv: $(VENV_ACTIVATE)
+
+$(VENV_ACTIVATE): setup.py setup.cfg
+	test -d .venv || $(VENV_BIN) .venv
+	$(VENV_RUN); pip install --upgrade pip setuptools plux wheel
+	$(VENV_RUN); pip install --upgrade black isort pyproject-flake8 flake8-black flake8-isort
+	$(VENV_RUN); pip install -e .
+	touch $(VENV_DIR)/bin/activate
+
+clean:
+	rm -rf .venv/
+	rm -rf build/
+	rm -rf .eggs/
+	rm -rf *.egg-info/
+
+lint:              		  ## Run code linter to check code style
+	($(VENV_RUN); python -m pflake8 --show-source)
+
+format:            		  ## Run black and isort code formatter
+	$(VENV_RUN); python -m isort helloworld; python -m black helloworld
+
+install: venv
+	$(VENV_RUN); python setup.py develop
+
+dist: venv
+	$(VENV_RUN); python setup.py sdist bdist_wheel
+
+publish: clean-dist venv dist
+	$(VENV_RUN); pip install --upgrade twine; twine upload dist/*
+
+clean-dist: clean
+	rm -rf dist/
+
+.PHONY: clean clean-dist dist install publish

--- a/hello-world/README.md
+++ b/hello-world/README.md
@@ -3,12 +3,12 @@ Hello World LocalStack extension
 
 A minimal LocalStack extension.
 
-## Installing
-
-```bash
-localstack extensions install "git+https://github.com/localstack/localstack-extensions/#egg=localstack-extension-hello-world&subdirectory=hello-world"
-```
-
 ## What does it do?
 
 It just prints a message to stdout once LocalStack starts, and a second time once the platform is ready to serve requests.
+
+## Installing
+
+```bash
+localstack extensions install localstack-extension-hello-world
+```

--- a/hello-world/helloworld/extension.py
+++ b/hello-world/helloworld/extension.py
@@ -1,7 +1,7 @@
 from localstack.extensions.api import Extension
 
 class HelloWorldExtension(Extension):
-    name = "hello_world_example"
+    name = "hello-world"
 
     def on_platform_start(self):
         print("hello world: localstack is starting!")

--- a/hello-world/helloworld/extension.py
+++ b/hello-world/helloworld/extension.py
@@ -1,5 +1,6 @@
 from localstack.extensions.api import Extension
 
+
 class HelloWorldExtension(Extension):
     name = "hello-world"
 

--- a/hello-world/pyproject.toml
+++ b/hello-world/pyproject.toml
@@ -1,0 +1,19 @@
+# LocalStack project configuration
+[build-system]
+requires = ['setuptools', 'wheel', 'plux>=1.3.1']
+build-backend = "setuptools.build_meta"
+
+[tool.black]
+line_length = 100
+include = '(helloworld/.*\.py$)'
+
+[tool.isort]
+profile = 'black'
+line_length = 100
+
+# call using pflake8
+[tool.flake8]
+max-line-length = 110
+ignore = 'E203,E266,E501,W503,F403'
+select = 'B,C,E,F,I,W,T4,B9'
+exclude = '.venv*,venv*,dist,*.egg-info,.git'

--- a/hello-world/setup.cfg
+++ b/hello-world/setup.cfg
@@ -14,4 +14,4 @@ install_requires =
 
 [options.entry_points]
 localstack.extensions =
-    hello_world_example = helloworld.extension:HelloWorldExtension
+    hello-world = helloworld.extension:HelloWorldExtension

--- a/hello-world/setup.cfg
+++ b/hello-world/setup.cfg
@@ -1,7 +1,10 @@
 [metadata]
 name = localstack-extension-hello-world
-version = 0.0.1
-description = LocalStack hello world extension Example
+version = 0.1.0
+summary = LocalStack Extension: Hello World
+description = A hello world example extension for Localstack, showing how extensions should be organized
+long_description = file: README.md
+long_description_content_type = text/markdown
 url = https://github.com/localstack/localstack-extensions/tree/main/hello-world
 author = Thomas Rausch
 author_email = thomas@localstack.cloud
@@ -10,7 +13,7 @@ author_email = thomas@localstack.cloud
 zip_safe = False
 packages = find:
 install_requires =
-    localstack>=0.14.4.dev
+    localstack>=1.0
 
 [options.entry_points]
 localstack.extensions =


### PR DESCRIPTION
I'm currently facing issues when trying to find out which extensions are installed, since the name of the extensions do not match what's in the name of `setup.cfg`. 
Hence I'm renaming this extension to just `hello-world` as that is included in it's name `localstack-extension-hello-world`