### PR TITLE
upgrade localstripe to our fork

### DIFF
--- a/stripe/setup.cfg
+++ b/stripe/setup.cfg
@@ -29,8 +29,8 @@ setup_requires =
 install_requires =
     stevedore>=3.4
     plux>=1.3
-    localstack>=0.14.4.dev
-    localstripe>=1.13
+    localstack>=1.0
+    localstack-localstripe>=1.13.8
 test_requires =
     pytest>=6.2.4
 


### PR DESCRIPTION
I released our fork of localstripe https://github.com/localstack/localstripe/ under https://pypi.org/project/localstack-localstripe/ which includes the latest upstream changes + some of our fixes.

/cc @pandomic
