### PR TITLE
add summary field to cookie cutter template

### DIFF
--- a/template/{{cookiecutter.project_slug}}/setup.cfg
+++ b/template/{{cookiecutter.project_slug}}/setup.cfg
@@ -1,6 +1,7 @@
 [metadata]
 name = {{ cookiecutter.project_slug }}
 version = {{ cookiecutter.version }}
+summary = LocalStack Extension: {{ cookiecutter.project_name }}
 url = https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}
 author = {{ cookiecutter.full_name }}
 author_email = {{ cookiecutter.email }}


### PR DESCRIPTION
A small prep for the upcoming hackathon: including the summary field in our template, which is used in the webapp to display the extension name.