### PR TITLE
Make httpbin extension compatible with Werkzeug 3.x

### DIFF
--- a/httpbin/localstack_httpbin/extension.py
+++ b/httpbin/localstack_httpbin/extension.py
@@ -1,10 +1,11 @@
 import logging
 from typing import Optional
 
-from localstack import config, constants
+from localstack import config
 from localstack.config import get_edge_url
 from localstack.extensions.api import Extension, http
 from localstack.utils.net import get_free_tcp_port
+from localstack.utils.urls import localstack_host
 
 from localstack_httpbin.server import HttpbinServer
 
@@ -28,15 +29,13 @@ class HttpbinExtension(Extension):
 
     def on_platform_start(self):
         from localstack_httpbin.vendor.httpbin import core
-        core.template['host'] = f"{self.get_public_hostname()}:{config.get_edge_port_http()}"
-
+        core.template['host'] = f"{self.get_public_hostname()}:{localstack_host().port}"
         self.server = HttpbinServer(get_free_tcp_port())
         LOG.debug("starting httpbin on %s", self.server.url)
         self.server.start()
 
     def get_public_hostname(self) -> str:
-        # FIXME: reconcile with LOCALSTACK_HOST, but this should be accessible via the host
-        return  f"{self.hostname_prefix}{constants.LOCALHOST_HOSTNAME}"
+        return f"{self.hostname_prefix}{localstack_host().host}"
 
     def on_platform_ready(self):
         LOG.info("Serving httpbin on %s", get_edge_url(localstack_hostname=self.get_public_hostname()))

--- a/httpbin/localstack_httpbin/vendor/httpbin/helpers.py
+++ b/httpbin/localstack_httpbin/vendor/httpbin/helpers.py
@@ -13,8 +13,7 @@ import re
 import time
 import os
 from hashlib import md5, sha256, sha512
-from werkzeug.http import parse_authorization_header
-from werkzeug.datastructures import WWWAuthenticate
+from werkzeug.datastructures import WWWAuthenticate, Authorization
 
 from flask import request, make_response
 from six.moves.urllib.parse import urlparse, urlunparse
@@ -356,7 +355,7 @@ def check_digest_auth(user, passwd):
     """Check user authentication using HTTP Digest auth"""
 
     if request.headers.get('Authorization'):
-        credentials = parse_authorization_header(request.headers.get('Authorization'))
+        credentials = Authorization.from_header(request.headers.get('Authorization'))
         if not credentials:
             return
         request_uri = request.script_root + request.path


### PR DESCRIPTION
## Changes

- Remove usage of deprecated `get_edge_port_http` (/cc @simonrw @joe4dev )
- Fix auth parsing

# Left to do

- Fix `digest_challenge_response`. It seems there's no `WWWAuthenticate.set_digest` anymore which leads to errors when trying to use digest auth. Will fix this in a follow-up PR. This PR should now at least make it start correctly