### PR TITLE
update miniflare extension to properly work with v3

### DIFF
--- a/miniflare/miniflare/cloudflare_api.py
+++ b/miniflare/miniflare/cloudflare_api.py
@@ -154,6 +154,8 @@ def handle_services(request: Request, account_id: str, service_name: str) -> dic
         }
     )
 
+def handle_standard(request: Request, account_id: str) -> dict:
+    return _wrap({})
 
 def handle_subdomain(request: Request, account_id: str) -> dict:
     return _wrap({})

--- a/miniflare/miniflare/extension.py
+++ b/miniflare/miniflare/extension.py
@@ -19,6 +19,7 @@ from miniflare.cloudflare_api import (
     handle_scripts,
     handle_secrets,
     handle_services,
+    handle_standard,
     handle_subdomain,
     handle_user,
 )
@@ -54,6 +55,7 @@ class MiniflareExtension(Extension):
             "/accounts/<account_id>/workers/services/<service_name>", handle_services
         )
         _add_route("/accounts/<account_id>/workers/subdomain", handle_subdomain)
+        _add_route("/accounts/<account_id>/workers/standard", handle_standard)
         _add_route(
             "/accounts/<account_id>/workers/scripts/<script_name>/subdomain",
             handle_script_subdomain,
@@ -125,7 +127,7 @@ class MiniflareInstaller(ExecutableInstaller):
         # note: latest version of miniflare/workerd requires libc++ dev libs
         if config.is_in_docker:
             sources_list_file = "/etc/apt/sources.list"
-            sources_list = load_file(sources_list_file)
+            sources_list = load_file(sources_list_file) or ""
             sources_list += "\ndeb https://deb.debian.org/debian testing main contrib"
             save_file(sources_list_file, sources_list)
             run(["apt", "update"])


### PR DESCRIPTION
This PR prepares the miniflare extension for v3.

Seems like wrangler has gotten an update, requiring the newly added `/accounts/<account_id>/workers/standard` route, since when trying to execute `wrangler publish` I faced this issue: 
```
localstack.aws.protocol.parser.OperationNotFoundParserError: Unable to find operation for request to service apigateway: GET /miniflare/accounts/01a7362d577a6c3019a474fd6f485823/workers/standard
```

Furthermore fixing a small bug, i.e. `sources_list = load_file(sources_list_file) or ""`, since without it the extension raised an exception.

Can confirm I can now deploy an application with wrangler against latest localstack.