### PR TITLE
improve extension descriptions as they will be used for display in the webapp

### DIFF
--- a/hello-world/setup.cfg
+++ b/hello-world/setup.cfg
@@ -2,7 +2,7 @@
 name = localstack-extension-hello-world
 version = 0.1.0
 summary = LocalStack Extension: Hello World
-description = A hello world example extension for Localstack, showing how extensions should be organized
+description = A minimal LocalStack extension
 long_description = file: README.md
 long_description_content_type = text/markdown
 url = https://github.com/localstack/localstack-extensions/tree/main/hello-world

--- a/mailhog/setup.cfg
+++ b/mailhog/setup.cfg
@@ -5,7 +5,7 @@ url = https://github.com/localstack/localstack-extensions/tree/main/mailhog
 author = LocalStack
 author_email = info@localstack.cloud
 summary: LocalStack Extension: MailHog
-description = Web and API based STMP testing directly in LocalStack
+description = Web and API based SMTP testing directly in LocalStack using MailHog
 long_description = file: README.md
 long_description_content_type = text/markdown; charset=UTF-8
 

--- a/miniflare/setup.cfg
+++ b/miniflare/setup.cfg
@@ -2,7 +2,7 @@
 name = localstack-extension-miniflare
 version = 0.1.0
 summary = LocalStack Extension: Miniflare
-description = Extension to run Miniflare on LocalStack
+description = This extension makes Miniflare (dev environment for Cloudflare workers) available directly in LocalStack
 long_description = file: README.md
 long_description_content_type = text/markdown
 url = https://github.com/localstack/localstack-extensions/tree/main/miniflare

--- a/stripe/setup.cfg
+++ b/stripe/setup.cfg
@@ -5,7 +5,7 @@ url = https://github.com/localstack/localstack-extensions/tree/main/stripe
 author = Thomas Rausch
 author_email = thomas@localstack.cloud
 summary = LocalStack Extension: Stripe
-description = Stripe extension for LocalStack
+description = A LocalStack extension that provides a mocked version of Stripe as a service
 long_description = file: README.md
 long_description_content_type = text/markdown; charset=UTF-8
 license = Apache License 2.0


### PR DESCRIPTION
In preparation for moving away from pypi as the source for metadata for our extensions, I'll use the metadata available in the `setup.cfg`s of each extension for now. In the future I'll move to entities stored in our DB as that allows for more fields (i.e. web app url /cc @whummer).

Hence I'm updating some descriptions to be properly displayed as can be seen below:
![Screenshot 2023-11-15 at 11 11 40](https://github.com/localstack/localstack-extensions/assets/39307517/7ac49707-fc59-49ee-b664-05bc35e5765d)
