### PR TITLE
[minor] Adjust aws-replicator code imports for v3 changes

### DIFF
--- a/.github/workflows/aws-replicator.yml
+++ b/.github/workflows/aws-replicator.yml
@@ -82,8 +82,6 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.TEST_AWS_SECRET_ACCESS_KEY }}
           LOCALSTACK_API_KEY: ${{ secrets.LOCALSTACK_API_KEY }}
         run: |
-          # TODO tmp fix for https://github.com/localstack/localstack/issues/8267:
-          pip install --upgrade 'botocore<1.31.81'
           cd aws-replicator/example
           make test
 

--- a/aws-replicator/README.md
+++ b/aws-replicator/README.md
@@ -115,6 +115,7 @@ localstack extensions install "git+https://github.com/localstack/localstack-exte
 
 ## Change Log
 
+* `0.1.3`: Adjust code imports for recent LocalStack v3.0 module changes
 * `0.1.2`: Remove deprecated ProxyListener for starting local aws-replicator proxy server
 * `0.1.1`: Add simple configuration Web UI
 * `0.1.0`: Initial version of extension

--- a/aws-replicator/aws_replicator/client/auth_proxy.py
+++ b/aws-replicator/aws_replicator/client/auth_proxy.py
@@ -31,7 +31,7 @@ from localstack.utils.net import get_free_tcp_port
 from localstack.utils.server.http2_server import run_server
 from localstack.utils.serving import Server
 from localstack.utils.strings import short_uid, to_str, truncate
-from localstack_ext.bootstrap.licensing import ENV_LOCALSTACK_API_KEY
+from localstack_ext.bootstrap.licensingv2 import ENV_LOCALSTACK_API_KEY
 from requests import Response
 
 from aws_replicator.client.utils import truncate_content

--- a/aws-replicator/aws_replicator/client/auth_proxy.py
+++ b/aws-replicator/aws_replicator/client/auth_proxy.py
@@ -17,7 +17,7 @@ from localstack import config as localstack_config
 from localstack.aws.api import HttpRequest
 from localstack.aws.protocol.parser import create_parser
 from localstack.aws.spec import load_service
-from localstack.config import get_edge_url
+from localstack.config import internal_service_url
 from localstack.constants import AWS_REGION_US_EAST_1, DOCKER_IMAGE_NAME_PRO
 from localstack.http import Request
 from localstack.utils.aws.aws_responses import requests_response
@@ -30,7 +30,7 @@ from localstack.utils.functions import run_safe
 from localstack.utils.net import get_free_tcp_port
 from localstack.utils.server.http2_server import run_server
 from localstack.utils.serving import Server
-from localstack.utils.strings import short_uid, to_str, truncate
+from localstack.utils.strings import short_uid, to_bytes, to_str, truncate
 from localstack_ext.bootstrap.licensingv2 import ENV_LOCALSTACK_API_KEY
 from requests import Response
 
@@ -138,7 +138,7 @@ class AuthProxyAWS(Server):
         port = getattr(self, "port", None)
         if not port:
             raise Exception("Proxy currently not running")
-        url = f"{get_edge_url()}{HANDLER_PATH_PROXIES}"
+        url = f"{internal_service_url()}{HANDLER_PATH_PROXIES}"
         data = AddProxyRequest(port=port, config=self.config)
         try:
             response = requests.post(url, json=data)
@@ -214,6 +214,7 @@ class AuthProxyAWS(Server):
                     '<CreateBucketConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">'
                     f"<LocationConstraint>{region}</LocationConstraint></CreateBucketConfiguration>"
                 )
+
         if service_name == "sqs" and isinstance(req_body, dict):
             account_id = self._query_account_id_from_aws()
             if "QueueUrl" in req_body:
@@ -221,6 +222,14 @@ class AuthProxyAWS(Server):
                 req_body["QueueUrl"] = f"https://queue.amazonaws.com/{account_id}/{queue_name}"
             if "QueueOwnerAWSAccountId" in req_body:
                 req_body["QueueOwnerAWSAccountId"] = account_id
+        if service_name == "sqs" and request_dict.get("url"):
+            req_json = run_safe(lambda: json.loads(body_str)) or {}
+            account_id = self._query_account_id_from_aws()
+            queue_name = req_json.get("QueueName")
+            if account_id and queue_name:
+                request_dict["url"] = f"https://queue.amazonaws.com/{account_id}/{queue_name}"
+                req_json["QueueOwnerAWSAccountId"] = account_id
+                request_dict["body"] = to_bytes(json.dumps(req_json))
 
     def _fix_headers(self, request: HttpRequest, service_name: str):
         if service_name == "s3":

--- a/aws-replicator/setup.cfg
+++ b/aws-replicator/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = localstack-extension-aws-replicator
-version = 0.1.2
+version = 0.1.3
 summary = LocalStack Extension: AWS replicator
 description = Replicate AWS resources into your LocalStack instance
 long_description = file: README.md
@@ -16,8 +16,7 @@ install_requires =
     # TODO: currently requires a version pin, see note in auth_proxy.py
     boto3>=1.26.151
     # TODO: currently requires a version pin, see note in auth_proxy.py
-    # TODO: upper version pin due to https://github.com/localstack/localstack/issues/8267
-    botocore>=1.29.151,<1.31.81
+    botocore>=1.29.151
     flask
     localstack
     localstack-client


### PR DESCRIPTION
Adjust aws-replicator code imports for recent v3 changes
* remove version pins for `botocore`
* fix import of `ENV_LOCALSTACK_API_KEY`
* remove usage of deprecated `get_edge_url`
* small fix to get canonical service name (`sqs-query` -> `sqs`)