### PR TITLE
Fix imports of bootstrap.auth modules in aws-replicator

### DIFF
--- a/aws-replicator/README.md
+++ b/aws-replicator/README.md
@@ -115,6 +115,7 @@ localstack extensions install "git+https://github.com/localstack/localstack-exte
 
 ## Change Log
 
+* `0.1.4`: Fix imports of `bootstrap.auth` modules for v3.0 compatibility
 * `0.1.3`: Adjust code imports for recent LocalStack v3.0 module changes
 * `0.1.2`: Remove deprecated ProxyListener for starting local aws-replicator proxy server
 * `0.1.1`: Add simple configuration Web UI

--- a/aws-replicator/setup.cfg
+++ b/aws-replicator/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = localstack-extension-aws-replicator
-version = 0.1.3
+version = 0.1.4
 summary = LocalStack Extension: AWS replicator
 description = Replicate AWS resources into your LocalStack instance
 long_description = file: README.md


### PR DESCRIPTION
This PR fixes a couple more imports of bootstrap.auth modules in aws-replicator, and adjust the logic to be compatible with v3 (e.g., `LOCALSTACK_HOST`)