### PR TITLE
add initial CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,21 @@
+######################
+###  CODE OWNERS   ###
+######################
+
+# CODEOWNERS
+/CODEOWNERS @lukqw @thrau @alexrashed
+
+# Template for new extensions
+/template/ @lukqw @thrau
+
+######################
+###   Extensions   ###
+######################
+
+/aws-replicator/ @whummer
+/diagnosis-viewer/ @lukqw @thrau @silv-io
+/hello-world/ @lukqw @thrau
+/http-bin/ @lukqw @thrau @dominikschubert
+/mailhog/ @lukqw @thrau
+/miniflare/ @whummer @HarshCasper
+/stripe/ @lukqw @thrau

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -13,9 +13,9 @@
 ######################
 
 /aws-replicator/ @whummer
-/diagnosis-viewer/ @lukqw @thrau @silv-io
+/diagnosis-viewer/ @thrau @silv-io
 /hello-world/ @lukqw @thrau
-/http-bin/ @lukqw @thrau @dominikschubert
+/http-bin/ @thrau @dominikschubert
 /mailhog/ @lukqw @thrau
 /miniflare/ @whummer @HarshCasper
 /stripe/ @lukqw @thrau


### PR DESCRIPTION
## Motivation
This repo is a mono-repo containing some of our official LocalStack Extensions.
In order to make it transparent who is maintaining which, I thought it would be nice to have a `CODEOWNERS` file in this repo as a machine- and human-readable ownership documentation (which has the benefit of GitHub automatically assigning the right PR reviewers).

## Changes
- Initially adds a `CODEOWNERS` file.
  - The current content is up for debate and subject to change!
  - My initial list is derived from:
    - The commit history on the different folders.
    - An on an internal conversation.
    - And I added @silv-io because he's the maintainer of [`diapretty`](https://github.com/silv-io/diapretty) (used in the diagnosis-viewer extension).

I'm happy for any feedback (also to drop this again, if we decide that this isn't useful right now).