### PR TITLE
Adjust config to support `LOCALSTACK_AUTH_TOKEN` in addition to legacy API keys

### DIFF
--- a/.github/workflows/aws-replicator.yml
+++ b/.github/workflows/aws-replicator.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Install LocalStack and extension
         env:
-          LOCALSTACK_API_KEY: ${{ secrets.LOCALSTACK_API_KEY }}
+          LOCALSTACK_AUTH_TOKEN: ${{ secrets.TEST_LOCALSTACK_AUTH_TOKEN }}
         run: |
           docker pull localstack/localstack-pro &
           docker pull public.ecr.aws/lambda/python:3.8 &
@@ -80,7 +80,7 @@ jobs:
           AWS_DEFAULT_REGION: us-east-1
           AWS_ACCESS_KEY_ID: ${{ secrets.TEST_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.TEST_AWS_SECRET_ACCESS_KEY }}
-          LOCALSTACK_API_KEY: ${{ secrets.LOCALSTACK_API_KEY }}
+          LOCALSTACK_AUTH_TOKEN: ${{ secrets.TEST_LOCALSTACK_AUTH_TOKEN }}
         run: |
           cd aws-replicator/example
           make test

--- a/aws-replicator/README.md
+++ b/aws-replicator/README.md
@@ -115,6 +115,7 @@ localstack extensions install "git+https://github.com/localstack/localstack-exte
 
 ## Change Log
 
+* `0.1.6`: Adjust config to support `LOCALSTACK_AUTH_TOKEN` in addition to legacy API keys
 * `0.1.5`: Minor fix to accommodate recent upstream changes
 * `0.1.4`: Fix imports of `bootstrap.auth` modules for v3.0 compatibility
 * `0.1.3`: Adjust code imports for recent LocalStack v3.0 module changes

--- a/aws-replicator/aws_replicator/client/auth_proxy.py
+++ b/aws-replicator/aws_replicator/client/auth_proxy.py
@@ -31,7 +31,7 @@ from localstack.utils.net import get_free_tcp_port
 from localstack.utils.server.http2_server import run_server
 from localstack.utils.serving import Server
 from localstack.utils.strings import short_uid, to_bytes, to_str, truncate
-from localstack_ext.bootstrap.licensingv2 import ENV_LOCALSTACK_API_KEY
+from localstack_ext.bootstrap.licensingv2 import ENV_LOCALSTACK_API_KEY, ENV_LOCALSTACK_AUTH_TOKEN
 from requests import Response
 
 from aws_replicator.client.utils import truncate_content
@@ -342,6 +342,7 @@ def start_aws_auth_proxy_in_container(
         "AWS_SESSION_TOKEN",
         "AWS_DEFAULT_REGION",
         ENV_LOCALSTACK_API_KEY,
+        ENV_LOCALSTACK_AUTH_TOKEN,
     ]
     env_vars = env_vars or os.environ
     env_vars = select_attributes(dict(env_vars), env_var_names)

--- a/aws-replicator/setup.cfg
+++ b/aws-replicator/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = localstack-extension-aws-replicator
-version = 0.1.5
+version = 0.1.6
 summary = LocalStack Extension: AWS replicator
 description = Replicate AWS resources into your LocalStack instance
 long_description = file: README.md


### PR DESCRIPTION
Adjust config to support `LOCALSTACK_AUTH_TOKEN` in addition to legacy API keys.

The CI build has also been adjusted to use auth token rather than API key for running the integration tests.

/cc @HarshCasper 