### PR TITLE
switch to CI key

### DIFF
--- a/.github/workflows/aws-replicator.yml
+++ b/.github/workflows/aws-replicator.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Install LocalStack and extension
         env:
-          LOCALSTACK_AUTH_TOKEN: ${{ secrets.TEST_LOCALSTACK_AUTH_TOKEN }}
+          LOCALSTACK_API_KEY: ${{ secrets.LOCALSTACK_API_KEY }}
         run: |
           docker pull localstack/localstack-pro &
           docker pull public.ecr.aws/lambda/python:3.8 &
@@ -80,7 +80,7 @@ jobs:
           AWS_DEFAULT_REGION: us-east-1
           AWS_ACCESS_KEY_ID: ${{ secrets.TEST_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.TEST_AWS_SECRET_ACCESS_KEY }}
-          LOCALSTACK_AUTH_TOKEN: ${{ secrets.TEST_LOCALSTACK_AUTH_TOKEN }}
+          LOCALSTACK_API_KEY: ${{ secrets.LOCALSTACK_API_KEY }}
         run: |
           cd aws-replicator/example
           make test


### PR DESCRIPTION
In an effort to increase our dogfooding, we are using our CI keys wherever possible. This PR switches from using a personal auth token to a dedicated CI key.

I already created the according CI key and set it as the value of the secret `LOCALSTACK_API_KEY`.