### PR TITLE
rename mailhog plugin name

### DIFF
--- a/mailhog/mailhog/extension.py
+++ b/mailhog/mailhog/extension.py
@@ -32,7 +32,7 @@ class MailHogExtension(Extension):
     automatically delivered to mailhog. Neato burrito.
     """
 
-    name = "localstack-mailhog"
+    name = "mailhog"
 
     hostname_prefix = "mailhog."
     """Used for serving through a host rule."""


### PR DESCRIPTION
# Motivation
As part of making the UI of our extensions more visible we included a field `has_ui` on our extension entities, which shows a button in our webapp next to an extension in case they feature a UI.
![Screenshot 2024-01-31 at 15 13 35](https://github.com/localstack/localstack-extensions/assets/39307517/f4d02dcb-47ad-457e-a766-815c2c0f69c2)
Clicking on it, will take the plugin name, and build the url with it.
This is due to one of the patterns I have seen: our extensions UI path usually follows the structure of `plugin-name.localstack.localhost.cloud`

This is the case for [httpbin](https://github.com/localstack/localstack-extensions/blob/main/httpbin/localstack_httpbin/extension.py#L18) and [aws-replicator](https://github.com/localstack/localstack-extensions/blob/main/aws-replicator/aws_replicator/server/request_handler.py#L35).

However, mailhog seems to break this pattern, hence I'm trying to consolidate things.

Maybe this is something to take into account as part of solidifying the extensions api?
I.e. an utility function that adds an UI path to our router, by just taking the plugin name as hostname prefix, rather than allowing arbitrary additions.