### PR TITLE
docs(readme): Add usage steps for aws-replicator extension

### DIFF
--- a/aws-replicator/README.md
+++ b/aws-replicator/README.md
@@ -29,11 +29,11 @@ The AWS connection proxy can be used to forward certain API calls in LocalStack 
 #### CLI
 For example, in order to forward all API calls for DynamoDB/S3/Cognito to real AWS, the proxy can be started via the CLI as follows:
 
-1. Start Localstack via CLI
+1. Start LocalStack via CLI
 ```
 $ localstack start -d
 ```
-2. Enable Localstack AWS replicator from the Web Application Extension Library
+2. Enable LocalStack AWS replicator from the Web Application Extension Library
 3. After installation restart Localstack
 4. Install the AWS replicator CLI package
 ```
@@ -47,7 +47,7 @@ $ export AWS_ACCESS_KEY_ID=... AWS_SECRET_ACCESS_KEY=...
 ```
 $ localstack aws proxy -s dynamodb,s3,cognito-idp
 ```
-7. Now for example awslocal or aws-cli with Localstack's endpoint URL should communicate with the real account.
+7. Now, when issuing an API call against LocalStack (e.g., via `awslocal`), the invocation gets forwarded to real AWS and should return data from your real cloud resources.
 
 #### Proxy Configuration UI
 
@@ -64,9 +64,9 @@ EXTRA_CORS_ALLOWED_ORIGINS=https://aws-replicator.localhost.localstack.cloud:456
 
 ![configuration settings](etc/proxy-settings.png)
 
-5. Now we can communicate with the real resources via Localstack.
+5. Now we can communicate with the real AWS cloud resources, directly via LocalStack.
 
-To clean up the running proxy container simply click disable on the Replicator UI.
+To clean up the running proxy container simply click "disable" on the Replicator UI.
 
 ### Resource-specific proxying
 

--- a/aws-replicator/README.md
+++ b/aws-replicator/README.md
@@ -20,17 +20,51 @@ This extension currently offers two modes of operation: (1) the AWS connection p
 
 The AWS connection proxy can be used to forward certain API calls in LocalStack to real AWS, in order to enable seamless transition between local and remote resources.
 
-For example, in order to forward all API calls for DynamoDB/S3/Cognito to real AWS, the proxy can be started via the CLI as follows:
-```
-# configure terminal session to allow access to a real cloud account
-$ export AWS_ACCESS_KEY_ID=... AWS_SECRET_ACCESS_KEY=...
-# start proxy via the CLI
-$ localstack aws proxy -s dynamodb,s3,cognito-idp
-```
-
 **Warning:** Be careful when using the proxy - make sure to _never_ give access to production accounts or any critical/sensitive data!
 
 **Note:** The replicator CLI currently works only when installing the `localstack` CLI via `pip`. If you're downloading the `localstack` CLI as a [binary release](https://docs.localstack.cloud/getting-started/installation/#localstack-cli), then please use the proxy configuration UI described below.
+
+### Usage
+
+#### CLI
+For example, in order to forward all API calls for DynamoDB/S3/Cognito to real AWS, the proxy can be started via the CLI as follows:
+
+1. Start Localstack via CLI
+```
+$ localstack start -d
+```
+2. Enable Localstack AWS replicator from the Web Application Extension Library
+3. After installation restart Localstack
+4. Install the AWS replicator CLI package
+```
+$ pip install localstack-extension-aws-replicator
+```
+5. Configure real cloud account credentials in a new terminal session to allow access
+```
+$ export AWS_ACCESS_KEY_ID=... AWS_SECRET_ACCESS_KEY=...
+```
+6. Start proxy in aforementioned terminal session via the CLI
+```
+$ localstack aws proxy -s dynamodb,s3,cognito-idp
+```
+7. Now for example awslocal or aws-cli with Localstack's endpoint URL should communicate with the real account.
+
+#### Proxy Configuration UI
+
+1. Start Localstack with extra CORS
+```
+EXTRA_CORS_ALLOWED_ORIGINS=https://aws-replicator.localhost.localstack.cloud:4566 localstack start -d
+```
+
+2. Enable Localstack AWS replicator from the Web Application Extension Library
+
+3. Once the extension is installed, it will expose a small configuration endpoint in your LocalStack container under the following endpoint: http://localhost:4566/_localstack/aws-replicator/index.html . 
+
+4. Use this Web UI to define the proxy configuration (in YAML syntax), as well as the AWS credentials (AWS access key ID, secret access key, and optionally session token) and save configuration. The proxy should report enabled state and on the host a proxy container should spawn.
+
+![configuration settings](etc/proxy-settings.png)
+
+5. Now we can communicate with the real resources via Localstack.
 
 ### Resource-specific proxying
 
@@ -71,14 +105,6 @@ make_bucket: test123
 ```
 
 A more comprehensive sample, involving local Lambda functions combined with remote SQS queues and S3 buckets, can be found in the `example` folder of this repo.
-
-### Proxy Configuration UI
-
-Once the extension is installed, it will expose a small configuration endpoint in your LocalStack container under the following endpoint: http://localhost:4566/_localstack/aws-replicator/index.html . 
-
-Please use this Web UI to define the proxy configuration (in YAML syntax), as well as the AWS credentials (AWS access key ID, secret access key, and optionally session token).
-
-![configuration settings](etc/proxy-settings.png)
 
 ## Resource Replicator CLI
 

--- a/aws-replicator/README.md
+++ b/aws-replicator/README.md
@@ -66,6 +66,8 @@ EXTRA_CORS_ALLOWED_ORIGINS=https://aws-replicator.localhost.localstack.cloud:456
 
 5. Now we can communicate with the real resources via Localstack.
 
+To clean up the running proxy container simply click disable on the Replicator UI.
+
 ### Resource-specific proxying
 
 As an alternative to forwarding _all_ requests for a particular service, you can also proxy only requests for _specific_ resources to AWS.


### PR DESCRIPTION
# Motivation
New users might struggle with the usage of the extension.

# Changes
- Update docs with usage steps on the available 2 proxy usage methods