### PR TITLE
Fix imports after recent upstream CloudFormation changes

### DIFF
--- a/aws-replicator/README.md
+++ b/aws-replicator/README.md
@@ -150,6 +150,7 @@ localstack extensions install "git+https://github.com/localstack/localstack-exte
 
 ## Change Log
 
+* `0.1.11`: Fix broken imports after recent upstream CloudFormation changes
 * `0.1.10`: Add `REPLICATOR_PROXY_DOCKER_FLAGS` option to pass custom flags to proxy Docker containers
 * `0.1.9`: Enhance proxy networking and add `REPLICATOR_LOCALSTACK_HOST` config option
 * `0.1.8`: Add `REPLICATOR_CLEANUP_PROXY_CONTAINERS` option to skip removing proxy containers for debugging

--- a/aws-replicator/aws_replicator/server/request_handler.py
+++ b/aws-replicator/aws_replicator/server/request_handler.py
@@ -28,7 +28,6 @@ from aws_replicator.client.auth_proxy import (
 from aws_replicator.config import HANDLER_PATH_PROXIES, HANDLER_PATH_REPLICATE
 from aws_replicator.server import ui as web_ui
 from aws_replicator.server.aws_request_forwarder import AwsProxyHandler
-from aws_replicator.server.resource_replicator import ResourceReplicatorFormer2
 from aws_replicator.shared.models import AddProxyRequest, ReplicateStateRequest, ResourceReplicator
 
 LOG = logging.getLogger(__name__)
@@ -111,7 +110,9 @@ def handle_replicate_request(request: ReplicateStateRequest):
 
 
 def _get_replicator() -> ResourceReplicator:
-    # TODO deprecated
+    from aws_replicator.server.resource_replicator import ResourceReplicatorFormer2
+
+    # TODO deprecated - fix the implementation of the replicator/copy logic!
     # return ResourceReplicatorInternal()
     return ResourceReplicatorFormer2()
 

--- a/aws-replicator/setup.cfg
+++ b/aws-replicator/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = localstack-extension-aws-replicator
-version = 0.1.10
+version = 0.1.11
 summary = LocalStack Extension: AWS replicator
 description = Replicate AWS resources into your LocalStack instance
 long_description = file: README.md


### PR DESCRIPTION
Fix imports after recent upstream CloudFormation changes.

Resolving an issue recently reported by a user:
```
...
localstack-main  |   File "/var/lib/localstack/lib/extensions/python_venv/lib/python3.11/site-packages/aws_replicator/server/extension.py", line 14, in update_gateway_routes
localstack-main  |     from aws_replicator.server.request_handler import RequestHandler
localstack-main  |   File "/var/lib/localstack/lib/extensions/python_venv/lib/python3.11/site-packages/aws_replicator/server/request_handler.py", line 31, in <module>
localstack-main  |     from aws_replicator.server.resource_replicator import ResourceReplicatorFormer2
localstack-main  |   File "/var/lib/localstack/lib/extensions/python_venv/lib/python3.11/site-packages/aws_replicator/server/resource_replicator.py", line 12, in <module>
localstack-main  |     from aws_replicator.client.service_states import ExtendedResourceStateReplicator
localstack-main  |   File "/var/lib/localstack/lib/extensions/python_venv/lib/python3.11/site-packages/aws_replicator/client/service_states.py", line 6, in <module>
localstack-main  |     from localstack.services.cloudformation.models.s3 import S3Bucket
localstack-main  | ModuleNotFoundError: No module named 'localstack.services.cloudformation.models.s3'
localstack-main  | 2024-03-06T22:33:55.357  INFO --- [-functhread4] hypercorn.error            : Running on https://0.0.0.0:4566/ (CTRL + C to quit)
```

The imports are now deferred until actually required in the processing flow. In a future iteration, we need to fix the replicator "copy" logic entirely, it is currently mostly broken (only the replicator "proxy" logic is currently maintained).

/cc @lakkeger 