### PR TITLE
modify aws credentials text field type to password

### DIFF
--- a/aws-replicator/README.md
+++ b/aws-replicator/README.md
@@ -150,6 +150,7 @@ localstack extensions install "git+https://github.com/localstack/localstack-exte
 
 ## Change Log
 
+* `0.1.12`: Modify aws credentials text field type to password  
 * `0.1.11`: Fix broken imports after recent upstream CloudFormation changes
 * `0.1.10`: Add `REPLICATOR_PROXY_DOCKER_FLAGS` option to pass custom flags to proxy Docker containers
 * `0.1.9`: Enhance proxy networking and add `REPLICATOR_LOCALSTACK_HOST` config option

--- a/aws-replicator/aws_replicator/server/ui/app.js
+++ b/aws-replicator/aws_replicator/server/ui/app.js
@@ -91,12 +91,12 @@ const App = () => {
                 </TableRow>
                 <TableRow sx={{'&:last-child td, &:last-child th': {border: 0}}}>
                   <TableCell component="th" scope="row">AWS Credentials:</TableCell>
-                  <TableCell sx={{width: "80%"}}>
-                    <TextField value={accessKey} onChange={(e) => setAccessKey(e.target.value)} size="small" style={{width: "32%"}} placeholder="AWS_ACCESS_KEY_ID" /> {" "}
-                    <TextField value={secretKey} onChange={(e) => setSecretKey(e.target.value)} size="small" style={{width: "32%"}} placeholder="AWS_SECRET_ACCESS_KEY" /> {" "}
-                    <TextField value={sessionToken} onChange={(e) => setSessionToken(e.target.value)} size="small" style={{width: "32%"}} placeholder="AWS_SESSION_TOKEN" />
-                    Please note: AWS credentials are only passed in-memory to the LocalStack container and will <b>not</b> be persisted on disk. For security reasons, please make sure to use scoped credentials with the least set of required permissions (ideally read-only).
-                  </TableCell>
+                  <TableCell sx={{ width: "80%" }}>
+                        <TextField type="password" value={accessKey} onChange={(e) => setAccessKey(e.target.value)} size="small" style={{ width: "32%" }} placeholder="AWS_ACCESS_KEY_ID" /> {" "}
+                        <TextField type="password" value={secretKey} onChange={(e) => setSecretKey(e.target.value)} size="small" style={{ width: "32%" }} placeholder="AWS_SECRET_ACCESS_KEY" /> {" "}
+                        <TextField type="password" value={sessionToken} onChange={(e) => setSessionToken(e.target.value)} size="small" style={{ width: "32%" }} placeholder="AWS_SESSION_TOKEN" />
+                        Please note: AWS credentials are only passed in-memory to the LocalStack container and will <b>not</b> be persisted on disk. For security reasons, please make sure to use scoped credentials with the least set of required permissions (ideally read-only).
+                    </TableCell>
                 </TableRow>
                 <TableRow sx={{'&:last-child td, &:last-child th': {border: 0}}}>
                   <TableCell component="th" scope="row">

--- a/aws-replicator/setup.cfg
+++ b/aws-replicator/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = localstack-extension-aws-replicator
-version = 0.1.11
+version = 0.1.12
 summary = LocalStack Extension: AWS replicator
 description = Replicate AWS resources into your LocalStack instance
 long_description = file: README.md


### PR DESCRIPTION
This PR adds `TextField` as `password` to ensure secure entry for `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and `AWS_SESSION_TOKEN` during demos or live sessions.