### PR TITLE
migrate to localstack auth login

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Extensions are a LocalStack Pro feature.
 To use and install extensions, use the CLI to first log in to your account
 
 ```console
-$ localstack login
+$ localstack auth login
 Please provide your login credentials below
 Username: ...
 ```


### PR DESCRIPTION
## Motivation
`localstack login` has been deprecated in favor of `localstack auth login` for quite a while (at least `3.0`).

## Changes
This PR changes the usages of `localstack login` in this repo to `localstack auth login`.