### PR TITLE
Migrate beta to preview terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LocalStack Extensions (beta)
+# LocalStack Extensions (Preview)
 
 <p align="center">
   <img src="https://user-images.githubusercontent.com/3996682/184503940-c30bfcac-e049-4ee4-b905-207b340111d1.png" alt="LocalStack Extensions">
@@ -6,7 +6,7 @@
 
 With LocalStack 1.0 we have introduced LocalStack Extensions that allow
 developers to extend and customize LocalStack. Both the feature and the API
-are currently experimental and may be subject to change.
+are currently in preview and may be subject to change.
 
 ## Using Extensions
 
@@ -24,11 +24,10 @@ $ localstack extensions --help
 
 Usage: localstack extensions [OPTIONS] COMMAND [ARGS]...
 
-  (Beta) Manage LocalStack extensions.
+  (Preview) Manage LocalStack extensions.
 
   LocalStack Extensions allow developers to extend and customize LocalStack.
-  The feature and the API are currently experimental and may be subject to
-  change.
+  The feature and the API are currently in a preview stage and may be subject to change.
 
   Visit https://docs.localstack.cloud/references/localstack-extensions/
   for more information on LocalStack Extensions.


### PR DESCRIPTION
## Motivation

Migrate to the unified **preview** and **experimental** terminology following our internal decision doc [📢 Communicate maturity levels of features under development](https://www.notion.so/localstack/Communicate-maturity-levels-of-features-under-development-0818dfff6a4943488cf2ffba780e730d?pvs=4).

## Changes

* Change "beta" to "preview"
