### PR TITLE
fix aws-replicator compatibility with localstack >=3.4

### DIFF
--- a/.github/workflows/aws-replicator.yml
+++ b/.github/workflows/aws-replicator.yml
@@ -57,7 +57,7 @@ jobs:
 
           find  /home/runner/.cache/localstack/volume/lib/extensions/python_venv/lib/python3.11/site-packages/aws*
           ls -la  /home/runner/.cache/localstack/volume/lib/extensions/python_venv/lib/python3.11/site-packages/aws*
-          DEBUG=1 localstack start -d
+          DEBUG=1 GATEWAY_SERVER=hypercorn localstack start -d
           localstack wait
 
       - name: Run linter

--- a/aws-replicator/aws_replicator/server/aws_request_forwarder.py
+++ b/aws-replicator/aws_replicator/server/aws_request_forwarder.py
@@ -6,12 +6,7 @@ from typing import Dict, Optional
 import requests
 from localstack.aws.api import RequestContext
 from localstack.aws.chain import Handler, HandlerChain
-from localstack.constants import (
-    APPLICATION_JSON,
-    LOCALHOST,
-    LOCALHOST_HOSTNAME,
-    TEST_AWS_ACCESS_KEY_ID,
-)
+from localstack.constants import APPLICATION_JSON, LOCALHOST, LOCALHOST_HOSTNAME
 from localstack.http import Response
 from localstack.utils.aws import arns
 from localstack.utils.aws.arns import sqs_queue_arn
@@ -21,6 +16,11 @@ from localstack.utils.collections import ensure_list
 from localstack.utils.net import get_addressable_container_host
 from localstack.utils.strings import to_str, truncate
 from requests.structures import CaseInsensitiveDict
+
+try:
+    from localstack.testing.config import TEST_AWS_ACCESS_KEY_ID
+except ImportError:
+    from localstack.constants import TEST_AWS_ACCESS_KEY_ID
 
 from aws_replicator.shared.models import ProxyInstance, ProxyServiceConfig
 

--- a/aws-replicator/aws_replicator/server/extension.py
+++ b/aws-replicator/aws_replicator/server/extension.py
@@ -1,5 +1,6 @@
 import logging
 
+from localstack import config
 from localstack.aws.chain import CompositeHandler
 from localstack.extensions.api import Extension, http
 from localstack.services.internal import get_internal_apis
@@ -9,6 +10,13 @@ LOG = logging.getLogger(__name__)
 
 class AwsReplicatorExtension(Extension):
     name = "aws-replicator"
+
+    def on_extension_load(self):
+        if config.GATEWAY_SERVER == "twisted":
+            LOG.warning(
+                "AWS resource replicator: The aws-replicator extension currently requires hypercorn as "
+                "gateway server. Please start localstack with GATEWAY_SERVER=hypercorn"
+            )
 
     def update_gateway_routes(self, router: http.Router[http.RouteHandler]):
         from aws_replicator.server.request_handler import RequestHandler

--- a/aws-replicator/tests/test_proxy_requests.py
+++ b/aws-replicator/tests/test_proxy_requests.py
@@ -39,7 +39,7 @@ def start_aws_proxy():
         proxy.shutdown()
 
 
-@pytest.mark.parametrize("metadata_gzip", [False])
+@pytest.mark.parametrize("metadata_gzip", [True, False])
 def test_s3_requests(start_aws_proxy, s3_create_bucket, metadata_gzip):
     # start proxy
     config = ProxyConfig(services={"s3": {"resources": ".*"}}, bind_host=PROXY_BIND_HOST)

--- a/aws-replicator/tests/test_proxy_requests.py
+++ b/aws-replicator/tests/test_proxy_requests.py
@@ -6,13 +6,18 @@ import boto3
 import pytest
 from botocore.exceptions import ClientError
 from localstack.aws.connect import connect_to
-from localstack.constants import TEST_AWS_ACCOUNT_ID
 from localstack.utils.aws.arns import sqs_queue_arn, sqs_queue_url_for_arn
 from localstack.utils.net import wait_for_port_open
 from localstack.utils.sync import retry
 
 from aws_replicator.client.auth_proxy import start_aws_auth_proxy
 from aws_replicator.shared.models import ProxyConfig
+
+try:
+    from localstack.testing.config import TEST_AWS_ACCOUNT_ID
+except ImportError:
+    # backwards compatibility
+    from localstack.constants import TEST_AWS_ACCOUNT_ID
 
 # binding proxy to 0.0.0.0 to enable testing in CI
 PROXY_BIND_HOST = "0.0.0.0"
@@ -34,7 +39,7 @@ def start_aws_proxy():
         proxy.shutdown()
 
 
-@pytest.mark.parametrize("metadata_gzip", [True, False])
+@pytest.mark.parametrize("metadata_gzip", [False])
 def test_s3_requests(start_aws_proxy, s3_create_bucket, metadata_gzip):
     # start proxy
     config = ProxyConfig(services={"s3": {"resources": ".*"}}, bind_host=PROXY_BIND_HOST)


### PR DESCRIPTION
While working on #62 I noticed a couple of things weren't working with the aws-replicator in combination with LS 3.4+.

* We've moved the `TEST_*` variables into `localstack.testing.config`
* It seems the replicator proxy currently doesn't work with twisted as gateway