### PR TITLE
Fix base_testing_aws_client import after recent upstream changes

### DIFF
--- a/aws-replicator/tests/conftest.py
+++ b/aws-replicator/tests/conftest.py
@@ -2,7 +2,7 @@ import pytest
 from localstack.testing.aws.util import (
     base_aws_client_factory,
     base_aws_session,
-    primary_testing_aws_client,
+    base_testing_aws_client,
 )
 
 pytest_plugins = [
@@ -22,4 +22,4 @@ def aws_client_factory(aws_session):
 
 @pytest.fixture(scope="session")
 def aws_client(aws_client_factory):
-    return primary_testing_aws_client(aws_client_factory)
+    return base_testing_aws_client(aws_client_factory)


### PR DESCRIPTION
Fix `base_testing_aws_client` import after recent upstream changes. See https://github.com/localstack/localstack/pull/11010