### PR TITLE
Quick fix: Install missing dependencies into proxy container

### DIFF
--- a/aws-replicator/README.md
+++ b/aws-replicator/README.md
@@ -115,6 +115,8 @@ In addition to the proxy services configuration shown above, the following confi
 * `REPLICATOR_LOCALSTACK_HOST`: the target host to use when the proxy container connects to the LocalStack main container (automatically determined by default)
 * `REPLICATOR_PROXY_DOCKER_FLAGS`: additional flags that should be passed when creating the proxy Docker containers
 
+**Note:** Due to some recent changes in the core framework, make sure to start up your LocalStack container with the `GATEWAY_SERVER=hypercorn` configuration enabled, for backwards compatibility. This will be fixed in an upcoming release.
+
 ## Resource Replicator CLI
 
 The figure below illustrates how the extension can be used to replicate the state, e.g., an SQS queue and the messages contained in it, from AWS into your LocalStack instance.
@@ -150,6 +152,7 @@ localstack extensions install "git+https://github.com/localstack/localstack-exte
 
 ## Change Log
 
+* `0.1.14`: Install missing dependencies into proxy container for localstack >=3.4 compatibility
 * `0.1.13`: Add compatibility with localstack >=3.4; add http2-server; migrate to localstack auth login
 * `0.1.12`: Modify aws credentials text field type to password  
 * `0.1.11`: Fix broken imports after recent upstream CloudFormation changes

--- a/aws-replicator/aws_replicator/client/auth_proxy.py
+++ b/aws-replicator/aws_replicator/client/auth_proxy.py
@@ -327,7 +327,8 @@ def start_aws_auth_proxy_in_container(
     command = [
         "bash",
         "-c",
-        f"{venv_activate}; pip install --upgrade --no-deps '{CLI_PIP_PACKAGE}'",
+        # TODO: manually installing quart/h11/hypercorn as a dirty quick fix for now. To be fixed!
+        f"{venv_activate}; pip install h11 hypercorn quart; pip install --upgrade --no-deps '{CLI_PIP_PACKAGE}'",
     ]
     DOCKER_CLIENT.exec_in_container(container_name, command=command)
 

--- a/aws-replicator/setup.cfg
+++ b/aws-replicator/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = localstack-extension-aws-replicator
-version = 0.1.13
+version = 0.1.14
 summary = LocalStack Extension: AWS replicator
 description = Replicate AWS resources into your LocalStack instance
 long_description = file: README.md


### PR DESCRIPTION
Quick fix: Install missing dependencies into proxy container. This is a quick fix for now, proper fix to be implemented soon via https://github.com/localstack/localstack-extensions/pull/62