### PR TITLE
Small refactorings to fix CLI import errors for replicator

### DIFF
--- a/aws-replicator/aws_replicator/client/auth_proxy.py
+++ b/aws-replicator/aws_replicator/client/auth_proxy.py
@@ -14,7 +14,6 @@ from botocore.awsrequest import AWSPreparedRequest
 from botocore.model import OperationModel
 from localstack import config
 from localstack import config as localstack_config
-from localstack.aws.protocol.parser import create_parser
 from localstack.aws.spec import load_service
 from localstack.config import external_service_url
 from localstack.constants import AWS_REGION_US_EAST_1, DOCKER_IMAGE_NAME_PRO
@@ -158,6 +157,8 @@ class AuthProxyAWS(Server):
     def _parse_aws_request(
         self, request: Request, service_name: str, region_name: str, client
     ) -> Tuple[OperationModel, AWSPreparedRequest, Dict]:
+        from localstack.aws.protocol.parser import create_parser
+
         parser = create_parser(load_service(service_name))
         operation_model, parsed_request = parser.parse(request)
         request_context = {

--- a/aws-replicator/aws_replicator/client/cli.py
+++ b/aws-replicator/aws_replicator/client/cli.py
@@ -67,10 +67,7 @@ def _is_logged_in() -> bool:
     required=False,
 )
 def cmd_aws_proxy(services: str, config: str, container: bool, port: int, host: str):
-    from aws_replicator.client.auth_proxy import (
-        start_aws_auth_proxy,
-        start_aws_auth_proxy_in_container,
-    )
+    from aws_replicator.client.auth_proxy import start_aws_auth_proxy_in_container
 
     config_json: ProxyConfig = {"services": {}}
     if config:
@@ -84,6 +81,10 @@ def cmd_aws_proxy(services: str, config: str, container: bool, port: int, host: 
     try:
         if container:
             return start_aws_auth_proxy_in_container(config_json)
+
+        # note: deferring the import here, to avoid import errors in CLI context
+        from aws_replicator.client.auth_proxy import start_aws_auth_proxy
+
         proxy = start_aws_auth_proxy(config_json, port=port)
         proxy.join()
     except Exception as e:

--- a/aws-replicator/aws_replicator/shared/models.py
+++ b/aws-replicator/aws_replicator/shared/models.py
@@ -1,44 +1,8 @@
 import logging
 from abc import ABC, abstractmethod
-from typing import Any, Dict, List, Optional, Type, TypedDict, Union
-
-from botocore.client import BaseClient
-from localstack.services.cloudformation.service_models import GenericBaseModel
-from localstack.utils.objects import get_all_subclasses
-
-from aws_replicator.shared.utils import get_resource_type
+from typing import Any, Dict, List, Optional, TypedDict, Union
 
 LOG = logging.getLogger(__name__)
-
-
-class ExtendedResourceStateReplicator(GenericBaseModel):
-    """Extended resource models, used to replicate (inject) additional state into a resource instance"""
-
-    def add_extended_state_external(self, remote_client: BaseClient = None):
-        """Called in the context of external CLI execution to fetch/replicate resource details from a remote account"""
-
-    def add_extended_state_internal(self, state: Dict):
-        """Called in the context of the internal LocalStack instance to inject the state into a resource"""
-
-    @classmethod
-    def get_resource_instance(cls, resource: Dict) -> Optional["ExtendedResourceStateReplicator"]:
-        resource_type = get_resource_type(resource)
-        resource_class = cls.find_resource_classes().get(resource_type)
-        if resource_class:
-            return resource_class(resource)
-
-    @classmethod
-    def get_resource_class(
-        cls, resource_type: str
-    ) -> Optional[Type["ExtendedResourceStateReplicator"]]:
-        return cls.find_resource_classes().get(resource_type)
-
-    @classmethod
-    def find_resource_classes(cls) -> Dict[str, "ExtendedResourceStateReplicator"]:
-        return {
-            inst.cloudformation_type(): inst
-            for inst in get_all_subclasses(ExtendedResourceStateReplicator)
-        }
 
 
 class ReplicateStateRequest(TypedDict):


### PR DESCRIPTION
Small refactorings to fix CLI import errors for replicator. This was detected in a debugging session together with @robertlcx , where we saw a couple of errors related to importing the CLI code from Python 3.9.

```
...
  File "/Users/localstack/SynologyDrive/repos/localstack-snowflake-samples/airflow-dbt-transformation/.venv/lib/python3.9/site-packages/localstack/aws/protocol/parser.py", line 1047, in VirtualHostRewriter
    def _is_vhost_address_get_bucket(request: Request) -> str | None:
TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'
```
...
```
  File "/Users/localstack/SynologyDrive/repos/localstack-snowflake-samples/airflow-dbt-transformation/.venv/lib/python3.9/site-packages/localstack/services/cloudformation/service_models.py", line 27, in <module>
    class GenericBaseModel:
  File "/Users/localstack/SynologyDrive/repos/localstack-snowflake-samples/airflow-dbt-transformation/.venv/lib/python3.9/site-packages/localstack/services/cloudformation/service_models.py", line 110, in GenericBaseModel
    def physical_resource_id(self) -> str | None:
TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'
```
...
```
  File "/Users/localstack/SynologyDrive/repos/localstack-snowflake-samples/airflow-dbt-transformation/.venv/lib/python3.9/site-packages/rolo/websocket/websocket.py", line 10, in <module>
    from rolo.asgi import ASGIWebSocket, WebSocketEnvironment, WebSocketListener
  File "/Users/localstack/SynologyDrive/repos/localstack-snowflake-samples/airflow-dbt-transformation/.venv/lib/python3.9/site-packages/rolo/asgi.py", line 46, in <module>
    WebSocketEnvironment: t.TypeAlias = t.Dict[str, t.Any]
AttributeError: module 'typing' has no attribute 'TypeAlias'
```


In this PR we're removing a couple of imports or try to defer them to later stages, to be able to run the replicator proxy from the CLI (in container mode) via:
```
$ localstack aws proxy --container -s s3
... 
```