### PR TITLE
AWS Replicator - regex match `secretsmanager` secrets based on their ARNs

### DIFF
--- a/aws-replicator/README.md
+++ b/aws-replicator/README.md
@@ -152,6 +152,7 @@ localstack extensions install "git+https://github.com/localstack/localstack-exte
 
 ## Change Log
 
+* `0.1.17`: Add basic support for ARN-based pattern-matching for `secretsmanager` resources
 * `0.1.16`: Update imports for localstack >=3.6 compatibility
 * `0.1.15`: Move localstack dependency installation to extra since it's provided at runtime
 * `0.1.14`: Install missing dependencies into proxy container for localstack >=3.4 compatibility

--- a/aws-replicator/aws_replicator/server/aws_request_forwarder.py
+++ b/aws-replicator/aws_replicator/server/aws_request_forwarder.py
@@ -121,7 +121,7 @@ class AwsProxyHandler(Handler):
         if service_name == "secretsmanager":
             secret_id = context.service_request.get("SecretId") or ""
             secret_arn = secretsmanager_secret_arn(secret_id, account_id=context.account_id, region_name=context.region)
-            return re.match(resource_name_pattern, secret_arn)
+            return bool(re.match(resource_name_pattern, secret_arn))
         # TODO: add more resource patterns
         return True
 

--- a/aws-replicator/aws_replicator/server/aws_request_forwarder.py
+++ b/aws-replicator/aws_replicator/server/aws_request_forwarder.py
@@ -9,7 +9,7 @@ from localstack.aws.chain import Handler, HandlerChain
 from localstack.constants import APPLICATION_JSON, LOCALHOST, LOCALHOST_HOSTNAME
 from localstack.http import Response
 from localstack.utils.aws import arns
-from localstack.utils.aws.arns import sqs_queue_arn, secretsmanager_secret_arn
+from localstack.utils.aws.arns import secretsmanager_secret_arn, sqs_queue_arn
 from localstack.utils.aws.aws_stack import get_valid_regions
 from localstack.utils.aws.request_context import mock_aws_request_headers
 from localstack.utils.collections import ensure_list
@@ -120,7 +120,9 @@ class AwsProxyHandler(Handler):
             return False
         if service_name == "secretsmanager":
             secret_id = context.service_request.get("SecretId") or ""
-            secret_arn = secretsmanager_secret_arn(secret_id, account_id=context.account_id, region_name=context.region)
+            secret_arn = secretsmanager_secret_arn(
+                secret_id, account_id=context.account_id, region_name=context.region
+            )
             return bool(re.match(resource_name_pattern, secret_arn))
         # TODO: add more resource patterns
         return True

--- a/aws-replicator/aws_replicator/server/aws_request_forwarder.py
+++ b/aws-replicator/aws_replicator/server/aws_request_forwarder.py
@@ -118,6 +118,12 @@ class AwsProxyHandler(Handler):
                 if re.match(resource_name_pattern, candidate):
                     return True
             return False
+        LOG.debug("Checking resource match for service %s: %s", service_name, resource_name_pattern)
+        LOG.debug("Service request: %s", context.service_request.__dict__)
+        # if service_name == "secretsmanager":
+        #     print("aicicicicii", resource_name_pattern, context.service_request)
+        #     secret_id = context.service_request.get("SecretId") or ""
+        #     return bool(re.match(resource_name_pattern, secret_id))
         # TODO: add more resource patterns
         return True
 

--- a/aws-replicator/aws_replicator/server/aws_request_forwarder.py
+++ b/aws-replicator/aws_replicator/server/aws_request_forwarder.py
@@ -9,7 +9,7 @@ from localstack.aws.chain import Handler, HandlerChain
 from localstack.constants import APPLICATION_JSON, LOCALHOST, LOCALHOST_HOSTNAME
 from localstack.http import Response
 from localstack.utils.aws import arns
-from localstack.utils.aws.arns import sqs_queue_arn
+from localstack.utils.aws.arns import sqs_queue_arn, secretsmanager_secret_arn
 from localstack.utils.aws.aws_stack import get_valid_regions
 from localstack.utils.aws.request_context import mock_aws_request_headers
 from localstack.utils.collections import ensure_list
@@ -118,12 +118,10 @@ class AwsProxyHandler(Handler):
                 if re.match(resource_name_pattern, candidate):
                     return True
             return False
-        LOG.debug("Checking resource match for service %s: %s", service_name, resource_name_pattern)
-        LOG.debug("Service request: %s", context.service_request.__dict__)
-        # if service_name == "secretsmanager":
-        #     print("aicicicicii", resource_name_pattern, context.service_request)
-        #     secret_id = context.service_request.get("SecretId") or ""
-        #     return bool(re.match(resource_name_pattern, secret_id))
+        if service_name == "secretsmanager":
+            secret_id = context.service_request.get("SecretId") or ""
+            secret_arn = secretsmanager_secret_arn(secret_id, account_id=context.account_id, region_name=context.region)
+            return re.match(resource_name_pattern, secret_arn)
         # TODO: add more resource patterns
         return True
 

--- a/aws-replicator/setup.cfg
+++ b/aws-replicator/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = localstack-extension-aws-replicator
-version = 0.1.16
+version = 0.1.17
 summary = LocalStack Extension: AWS replicator
 description = Replicate AWS resources into your LocalStack instance
 long_description = file: README.md


### PR DESCRIPTION
## Description

Specific proxy configs like:

```yaml
services:
  secretsmanager:
    resources:
      # list of ARNs of secrets to proxy to real AWS
      - 'arn:aws:secretsmanager:.+:secret:airflow/variables/.*'
    operations:
      # list of operation name regex patterns to include all operations
      - '.*'
    # optionally, specify if only read requests should be allowed; false allows all operations
    # read_only: true

```

Should be able to cast requests to upstream AWS for ARNs like `arn:aws:secretsmanager:.+:secret:airflow/variables/.*`, and everything else to LocalStack.

#### Limitations

Currently, this is only applicable to direct gets on said resources. The merging of the results from LocalStack and upstream AWS still has to be implemented in a subsequent PR.

In addition to that, regex matching the `account_id` and `region_name` params won't work because it will not represent the real values coming from upstream AWS. @whummer let me know if I'm missing anything here.

#### Future selves

Tests ought to be added as well in future PRs.