### PR TITLE
fix package conflict by moving localstack dep to dev extra

### DIFF
--- a/aws-replicator/setup.cfg
+++ b/aws-replicator/setup.cfg
@@ -18,9 +18,7 @@ install_requires =
     # TODO: currently requires a version pin, see note in auth_proxy.py
     botocore>=1.29.151
     flask
-    localstack
     localstack-client
-    localstack-ext
     xmltodict
     # TODO: refactor the use of http2_server
     hypercorn
@@ -37,6 +35,8 @@ install_requires =
 [options.extras_require]
 test =
     apispec
+    localstack-core
+    localstack-ext
     openapi-spec-validator
     pyproject-flake8
     pytest

--- a/diagnosis-viewer/Makefile
+++ b/diagnosis-viewer/Makefile
@@ -8,7 +8,6 @@ venv: $(VENV_ACTIVATE)
 $(VENV_ACTIVATE): setup.py setup.cfg
 	test -d .venv || $(VENV_BIN) .venv
 	$(VENV_RUN); pip install --upgrade pip setuptools plux wheel
-	$(VENV_RUN); pip install -e .
 	touch $(VENV_DIR)/bin/activate
 
 clean:
@@ -18,7 +17,7 @@ clean:
 	rm -rf *.egg-info/
 
 install: venv
-	$(VENV_RUN); python setup.py develop
+	$(VENV_RUN); python -m pip install -e .[dev]
 
 dist: venv
 	$(VENV_RUN); python setup.py sdist bdist_wheel

--- a/diagnosis-viewer/setup.cfg
+++ b/diagnosis-viewer/setup.cfg
@@ -13,8 +13,11 @@ long_description_content_type = text/markdown; charset=UTF-8
 zip_safe = False
 packages = find:
 install_requires =
-    localstack>=1.4
     diapretty
+
+[options.extras_require]
+dev =
+    localstack-core>=1.4
 
 [options.entry_points]
 localstack.extensions =

--- a/hello-world/Makefile
+++ b/hello-world/Makefile
@@ -9,7 +9,6 @@ $(VENV_ACTIVATE): setup.py setup.cfg
 	test -d .venv || $(VENV_BIN) .venv
 	$(VENV_RUN); pip install --upgrade pip setuptools plux wheel
 	$(VENV_RUN); pip install --upgrade black isort pyproject-flake8 flake8-black flake8-isort
-	$(VENV_RUN); pip install -e .
 	touch $(VENV_DIR)/bin/activate
 
 clean:
@@ -25,7 +24,7 @@ format:            		  ## Run black and isort code formatter
 	$(VENV_RUN); python -m isort helloworld; python -m black helloworld
 
 install: venv
-	$(VENV_RUN); python setup.py develop
+	$(VENV_RUN); python -m pip install -e .[dev]
 
 dist: venv
 	$(VENV_RUN); python setup.py sdist bdist_wheel

--- a/hello-world/setup.cfg
+++ b/hello-world/setup.cfg
@@ -12,8 +12,10 @@ author_email = thomas@localstack.cloud
 [options]
 zip_safe = False
 packages = find:
-install_requires =
-    localstack>=1.0
+
+[options.extras_require]
+dev =
+    localstack-core>=1.0
 
 [options.entry_points]
 localstack.extensions =

--- a/httpbin/Makefile
+++ b/httpbin/Makefile
@@ -9,7 +9,6 @@ $(VENV_ACTIVATE): setup.py setup.cfg
 	test -d .venv || $(VENV_BIN) .venv
 	$(VENV_RUN); pip install --upgrade pip setuptools plux wheel
 	$(VENV_RUN); pip install --upgrade black isort pyproject-flake8 flake8-black flake8-isort
-	$(VENV_RUN); pip install -e .
 	touch $(VENV_DIR)/bin/activate
 
 clean:
@@ -25,7 +24,7 @@ format: venv
 	$(VENV_RUN); python -m isort .; python -m black .
 
 install: venv
-	$(VENV_RUN); python setup.py develop
+	$(VENV_RUN); python -m pip install -e .[dev]
 
 dist: venv
 	$(VENV_RUN); python setup.py sdist bdist_wheel

--- a/httpbin/setup.cfg
+++ b/httpbin/setup.cfg
@@ -13,7 +13,6 @@ long_description_content_type = text/markdown; charset=UTF-8
 zip_safe = False
 packages = find:
 install_requires =
-    localstack>=2.2
     # requirements for vendored httpbin
     Flask
     MarkupSafe
@@ -23,6 +22,10 @@ install_requires =
     raven[flask]
     gevent
     flasgger
+
+[options.extras_require]
+dev =
+    localstack-core>=2.2
 
 [options.entry_points]
 localstack.extensions =

--- a/mailhog/Makefile
+++ b/mailhog/Makefile
@@ -9,7 +9,6 @@ $(VENV_ACTIVATE): setup.py setup.cfg
 	test -d .venv || $(VENV_BIN) .venv
 	$(VENV_RUN); pip install --upgrade pip setuptools plux wheel
 	$(VENV_RUN); pip install --upgrade black isort pyproject-flake8 flake8-black flake8-isort
-	$(VENV_RUN); pip install -e .
 	touch $(VENV_DIR)/bin/activate
 
 clean:
@@ -25,7 +24,7 @@ format:            		  ## Run black and isort code formatter
 	$(VENV_RUN); python -m isort mailhog; python -m black mailhog
 
 install: venv
-	$(VENV_RUN); python setup.py develop
+	$(VENV_RUN); python -m pip install -e .[dev]
 
 dist: venv
 	$(VENV_RUN); python setup.py sdist bdist_wheel

--- a/mailhog/setup.cfg
+++ b/mailhog/setup.cfg
@@ -12,8 +12,10 @@ long_description_content_type = text/markdown; charset=UTF-8
 [options]
 zip_safe = False
 packages = find:
-install_requires =
-    localstack>=2.2
+
+[options.extras_require]
+dev =
+    localstack-core>=2.2
 
 [options.entry_points]
 localstack.extensions =

--- a/miniflare/Makefile
+++ b/miniflare/Makefile
@@ -9,7 +9,6 @@ $(VENV_ACTIVATE): setup.py setup.cfg
 	test -d .venv || $(VENV_BIN) .venv
 	$(VENV_RUN); pip install --upgrade pip setuptools plux wheel
 	$(VENV_RUN); pip install --upgrade black isort pyproject-flake8 flake8-black flake8-isort
-	$(VENV_RUN); pip install -e .
 	touch $(VENV_DIR)/bin/activate
 
 clean:
@@ -25,7 +24,7 @@ format:            		  ## Run black and isort code formatter
 	$(VENV_RUN); python -m isort .; python -m black .
 
 install: venv
-	$(VENV_RUN); python setup.py develop
+	$(VENV_RUN); python -m pip install -e .[dev]
 
 dist: venv
 	$(VENV_RUN); python setup.py sdist bdist_wheel

--- a/miniflare/setup.cfg
+++ b/miniflare/setup.cfg
@@ -12,8 +12,10 @@ author_email = waldemar@localstack.cloud
 [options]
 zip_safe = False
 packages = find:
-install_requires =
-    localstack>=1.0.0
+
+[options.extras_require]
+dev =
+    localstack-core>=1.0.0
 
 [options.entry_points]
 localstack.extensions =

--- a/openai/Makefile
+++ b/openai/Makefile
@@ -9,7 +9,6 @@ $(VENV_ACTIVATE): setup.py setup.cfg
 	test -d .venv || $(VENV_BIN) .venv
 	$(VENV_RUN); pip install --upgrade pip setuptools plux wheel
 	$(VENV_RUN); pip install --upgrade black isort pyproject-flake8 flake8-black flake8-isort
-	$(VENV_RUN); pip install -e .
 	touch $(VENV_DIR)/bin/activate
 
 clean:
@@ -25,7 +24,7 @@ format:            		  ## Run black and isort code formatter
 	$(VENV_RUN); python -m isort .; python -m black .
 
 install: venv
-	$(VENV_RUN); python setup.py develop
+	$(VENV_RUN); python -m pip install -e .[dev]
 
 dist: venv
 	$(VENV_RUN); python setup.py sdist bdist_wheel

--- a/openai/setup.cfg
+++ b/openai/setup.cfg
@@ -24,7 +24,6 @@ zip_safe = False
 packages = find:
 install_requires =
     faker>=8.12.1
-    localstack>=3.1
     plux>=1.3
     rolo>=0.3
 test_requires =
@@ -33,6 +32,7 @@ test_requires =
 
 [options.extras_require]
 dev =
+    localstack-core>=3.1
     openai>=0.10.2,<1.0
     pytest>=6.2.4
     black==22.3.0

--- a/stripe/Makefile
+++ b/stripe/Makefile
@@ -32,7 +32,7 @@ dist: venv
 	$(VENV_ACTIVATE); python setup.py sdist bdist_wheel
 
 install: venv
-	$(VENV_ACTIVATE); python setup.py install
+	$(VENV_ACTIVATE); python -m pip install -e .[dev]
 
 upload: venv dist
 	$(VENV_ACTIVATE); pip install --upgrade twine; twine upload dist/*

--- a/stripe/setup.cfg
+++ b/stripe/setup.cfg
@@ -29,13 +29,13 @@ setup_requires =
 install_requires =
     stevedore>=3.4
     plux>=1.3
-    localstack>=1.0
     localstack-localstripe>=1.13.8
 test_requires =
     pytest>=6.2.4
 
 [options.extras_require]
 dev =
+    localstack-core>=1.0
     pytest>=6.2.4
     black==22.3.0
     isort==5.10.1

--- a/template/{{cookiecutter.project_slug}}/Makefile
+++ b/template/{{cookiecutter.project_slug}}/Makefile
@@ -8,7 +8,6 @@ venv: $(VENV_ACTIVATE)
 $(VENV_ACTIVATE): setup.py setup.cfg
 	test -d .venv || $(VENV_BIN) .venv
 	$(VENV_RUN); pip install --upgrade pip setuptools plux
-	$(VENV_RUN); pip install -e .
 	touch $(VENV_DIR)/bin/activate
 
 clean:
@@ -18,7 +17,7 @@ clean:
 	rm -rf *.egg-info/
 
 install: venv
-	$(VENV_RUN); python setup.py develop
+	$(VENV_RUN); python -m pip install -e .[dev]
 
 dist: venv
 	$(VENV_RUN); python setup.py sdist bdist_wheel

--- a/template/{{cookiecutter.project_slug}}/setup.cfg
+++ b/template/{{cookiecutter.project_slug}}/setup.cfg
@@ -12,8 +12,10 @@ long_description_content_type = text/markdown; charset=UTF-8
 [options]
 zip_safe = False
 packages = find:
-install_requires =
-    localstack>=1.0
+
+[options.extras_require]
+dev =
+    localstack-core>=1.0
 
 [options.entry_points]
 localstack.extensions =

--- a/terraform-init/Makefile
+++ b/terraform-init/Makefile
@@ -9,7 +9,6 @@ $(VENV_ACTIVATE): setup.py setup.cfg
 	test -d .venv || $(VENV_BIN) .venv
 	$(VENV_RUN); pip install --upgrade pip setuptools plux build
 	$(VENV_RUN); pip install --upgrade black isort
-	$(VENV_RUN); pip install -e .
 	touch $(VENV_DIR)/bin/activate
 
 clean:
@@ -19,7 +18,7 @@ clean:
 	rm -rf *.egg-info/
 
 install: venv
-	$(VENV_RUN); python setup.py develop
+	$(VENV_RUN); python -m pip install -e .[dev]
 
 format: venv
 	$(VENV_RUN); python -m isort .; python -m black .

--- a/terraform-init/setup.cfg
+++ b/terraform-init/setup.cfg
@@ -13,8 +13,11 @@ long_description_content_type = text/markdown; charset=UTF-8
 zip_safe = False
 packages = find:
 install_requires =
-    localstack-core>=3.4
     plux
+
+[options.extras_require]
+dev =
+    localstack-core>=3.4
 
 [options.entry_points]
 localstack.extensions =


### PR DESCRIPTION
## Motivation
With https://github.com/localstack/localstack/pull/11190, the `localstack` module is now an implicit namespace module.
However, in the latest release (3.5) this was not yet the case.
This uncovered an issue with the extensions if they define `localstack-core` (either directly or transitively via `localstack-core`) as an install-dependency:
- When installing the extension, the python package install dependencies are also installed into the extension virtual environment.
- When the extension defines an install-dependency on `localstack-core`, it will install the latest release of `localstack-core` into the extension virtual environment.
  - The extension virtual environment is directly linked to the main virtual environment in the LocalStack container and should directly use the code from the image (and not install it as an additional external dependency).
  - However, this currently causes a conflict because the installed version `3.5` - since it's not an implicit namespace package yet - which overwrites the module in the main venv.