### PR TITLE
fix missed version bumps for httpbin, miniflare, terraform-init

### DIFF
--- a/httpbin/setup.cfg
+++ b/httpbin/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = localstack-extension-httpbin
-version = 0.1.1
+version = 0.1.2
 url = https://github.com/localstack/localstack-extensions/tree/main/httpbin
 author = LocalStack
 author_email = info@localstack.cloud

--- a/miniflare/setup.cfg
+++ b/miniflare/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = localstack-extension-miniflare
-version = 0.1.1
+version = 0.1.2
 summary = LocalStack Extension: Miniflare
 description = This extension makes Miniflare (dev environment for Cloudflare workers) available directly in LocalStack
 long_description = file: README.md

--- a/terraform-init/setup.cfg
+++ b/terraform-init/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = localstack-extension-terraform-init
-version = 0.2.0
+version = 0.2.1
 summary = LocalStack Extension: LocalStack Terraform Init
 url = https://github.com/localstack/localstack-extensions/tree/main/terraform-init
 author = Thomas Rausch


### PR DESCRIPTION
## Motivation
With https://github.com/localstack/localstack-extensions/pull/73 we fixed the dependency declaration for the extensions in this repo and bumped the version to prepare a release of each and every one of the extensions.
Unfortunately, I forgot about the version bump in `httpbin`, `miniflare`, and `terraform-init`. The versions have already been released / published.

## Changes
- Bump the patch version for `httpbin`, `miniflare`, and `terraform-init`. 