### PR TITLE
Fix CLI command to enable starting the proxy from within Docker

### DIFF
--- a/aws-replicator/README.md
+++ b/aws-replicator/README.md
@@ -152,6 +152,7 @@ localstack extensions install "git+https://github.com/localstack/localstack-exte
 
 ## Change Log
 
+* `0.1.18`: Update environment check to use SDK Docker client and enable starting the proxy from within Docker (e.g., from the LS main container as part of an init script)
 * `0.1.17`: Add basic support for ARN-based pattern-matching for `secretsmanager` resources
 * `0.1.16`: Update imports for localstack >=3.6 compatibility
 * `0.1.15`: Move localstack dependency installation to extra since it's provided at runtime

--- a/aws-replicator/setup.cfg
+++ b/aws-replicator/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = localstack-extension-aws-replicator
-version = 0.1.17
+version = 0.1.18
 summary = LocalStack Extension: AWS replicator
 description = Replicate AWS resources into your LocalStack instance
 long_description = file: README.md


### PR DESCRIPTION
Update environment check to use SDK Docker client and enable starting the proxy from within Docker. 

The main use case is the ability to run the proxy container from within the LocalStack main container as part of an init script. /cc @RobertLucian 