### PR TITLE
introduce templates/ directory and add basic template

### DIFF
--- a/template/README.md
+++ b/template/README.md
@@ -1,6 +1,9 @@
 Extension Template
 ==================
 
+> [!NOTE]
+> This template is used for localstack CLI versions <= 3.6.0. For later version see https://github.com/localstack/localstack-extensions/tree/main/templates
+
 This is a [cookiecutter](https://github.com/cookiecutter/cookiecutter) template that is used when you invoke.
 
 ```console

--- a/templates/basic/README.md
+++ b/templates/basic/README.md
@@ -1,0 +1,10 @@
+Extension Template
+==================
+
+This is a [cookiecutter](https://github.com/cookiecutter/cookiecutter) template that is used when you invoke.
+
+```console
+localstack extensions dev new
+```
+
+It contains a simple python distribution config, and some boilerplate extension code.

--- a/templates/basic/cookiecutter.json
+++ b/templates/basic/cookiecutter.json
@@ -1,0 +1,11 @@
+{
+  "project_name": "My LocalStack Extension",
+  "project_short_description": "All the boilerplate you need to create a LocalStack extension.",
+  "project_slug": "{{ cookiecutter.project_name.lower().replace(' ', '-') }}",
+  "module_name": "{{ cookiecutter.project_slug.replace('-', '_') }}",
+  "class_name": "{{ cookiecutter.project_name.replace('-', ' ').replace('_', ' ').title().replace(' ', '') }}",
+  "full_name": "Jane Doe",
+  "email": "jane@example.com",
+  "github_username": "janedoe",
+  "version": "0.1.0"
+}

--- a/templates/basic/{{cookiecutter.project_slug}}/.gitignore
+++ b/templates/basic/{{cookiecutter.project_slug}}/.gitignore
@@ -1,0 +1,5 @@
+.venv
+dist
+build
+**/*.egg-info
+.eggs

--- a/templates/basic/{{cookiecutter.project_slug}}/Makefile
+++ b/templates/basic/{{cookiecutter.project_slug}}/Makefile
@@ -1,0 +1,32 @@
+VENV_BIN = python3 -m venv
+VENV_DIR ?= .venv
+VENV_ACTIVATE = $(VENV_DIR)/bin/activate
+VENV_RUN = . $(VENV_ACTIVATE)
+
+venv: $(VENV_ACTIVATE)
+
+$(VENV_ACTIVATE): pyproject.toml
+	test -d .venv || $(VENV_BIN) .venv
+	$(VENV_RUN); pip install --upgrade pip setuptools plux
+	$(VENV_RUN); pip install -e .[dev]
+	touch $(VENV_DIR)/bin/activate
+
+clean:
+	rm -rf .venv/
+	rm -rf build/
+	rm -rf .eggs/
+	rm -rf *.egg-info/
+
+install: venv
+	$(VENV_RUN); python -m plux entrypoints
+
+dist: venv
+	$(VENV_RUN); python -m build
+
+publish: clean-dist venv dist
+	$(VENV_RUN); pip install --upgrade twine; twine upload dist/*
+
+clean-dist: clean
+	rm -rf dist/
+
+.PHONY: clean clean-dist dist install publish

--- a/templates/basic/{{cookiecutter.project_slug}}/README.md
+++ b/templates/basic/{{cookiecutter.project_slug}}/README.md
@@ -1,0 +1,34 @@
+{{ cookiecutter.project_name }}
+===============================
+
+{{ cookiecutter.project_short_description }}
+
+## Install local development version
+
+To install the extension into localstack in developer mode, you will need Python 3.10, and create a virtual environment in the extensions project.
+
+In the newly generated project, simply run
+
+```bash
+make install
+```
+
+Then, to enable the extension for LocalStack, run
+
+```bash
+localstack extensions dev enable .
+```
+
+You can then start LocalStack with `EXTENSION_DEV_MODE=1` to load all enabled extensions:
+
+```bash
+EXTENSION_DEV_MODE=1 localstack start
+```
+
+## Install from GitHub repository
+
+To distribute your extension, simply upload it to your github account. Your extension can then be installed via:
+
+```bash
+localstack extensions install "git+https://github.com/{{cookiecutter.github_username }}/{{ cookiecutter.project_slug }}/#egg={{ cookiecutter.project_slug }}"
+```

--- a/templates/basic/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/templates/basic/{{cookiecutter.project_slug}}/pyproject.toml
@@ -1,0 +1,29 @@
+[build-system]
+requires = ["setuptools", 'wheel', 'plux>=1.3.1']
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "{{ cookiecutter.project_slug }}"
+version = "{{ cookiecutter.version }}"
+description = "LocalStack Extension: {{ cookiecutter.project_name }}"
+readme = {file = "README.md", content-type = "text/markdown; charset=UTF-8"}
+requires-python = ">=3.8"
+license = {text = "UNLICENSED"}
+authors = [
+    { name = "{{ cookiecutter.full_name }}", email = "{{ cookiecutter.email }}" }
+]
+keywords = ["localstack", "localstack-extension", "extension"]
+classifiers = []
+dependencies = [
+]
+
+[project.urls]
+Homepage = "https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}"
+
+[project.optional-dependencies]
+dev = [
+    "localstack>=0.0.0.dev"
+]
+
+[project.entry-points."localstack.extensions"]
+{{ cookiecutter.module_name }} = "{{ cookiecutter.module_name }}.extension:{{ cookiecutter.class_name }}"

--- a/templates/basic/{{cookiecutter.project_slug}}/{{cookiecutter.module_name}}/__init__.py
+++ b/templates/basic/{{cookiecutter.project_slug}}/{{cookiecutter.module_name}}/__init__.py
@@ -1,0 +1,1 @@
+name = "{{ cookiecutter.module_name }}"

--- a/templates/basic/{{cookiecutter.project_slug}}/{{cookiecutter.module_name}}/extension.py
+++ b/templates/basic/{{cookiecutter.project_slug}}/{{cookiecutter.module_name}}/extension.py
@@ -1,0 +1,22 @@
+from localstack.extensions.api import Extension, http, aws
+
+class {{ cookiecutter.class_name }}(Extension):
+    name = "{{ cookiecutter.project_slug }}"
+
+    def on_extension_load(self):
+        print("MyExtension: extension is loaded")
+
+    def on_platform_start(self):
+        print("MyExtension: localstack is starting")
+
+    def on_platform_ready(self):
+        print("MyExtension: localstack is running")
+
+    def update_gateway_routes(self, router: http.Router[http.RouteHandler]):
+        pass
+
+    def update_request_handlers(self, handlers: aws.CompositeHandler):
+        pass
+
+    def update_response_handlers(self, handlers: aws.CompositeResponseHandler):
+        pass


### PR DESCRIPTION
#69 introduced a change that adds a react template. To that end, we moved (copied) the existing into `templates/basic`, additional to `templates/react`. This PR extracts the change of adding `templates/basic`.

I also updated the template config to only use `pyproject.toml` and the more modern build config. Also cleaned up a couple of things in the Makefile.

This unblocks the PR for the localstack cli that introduces the --template directory.

If you run into the issue:
```
 % python -m localstack.cli.main extensions dev new
You've downloaded /home/thomas/.cookiecutters/localstack-extensions before. Is it okay to delete and re-download it? 
[y/n] (y): n
Do you want to re-use the existing version? [y/n] (y): y
❌ Error: A valid repository for "https://github.com/localstack/localstack-extensions" could not be found in the following locations:
/home/thomas/.cookiecutters/localstack-extensions/templates/basic
```

Then make sure you select `y` to re-download the templates