### PR TITLE
chore(mailhog): Adapted url to standard for extensions

### DIFF
--- a/mailhog/mailhog/server.py
+++ b/mailhog/mailhog/server.py
@@ -29,7 +29,7 @@ class MailHogServer(Server):
     It supports snapshot persistence by pointing the MH_MAILDIR_PATH to the asset directory.
     """
 
-    default_web_path = "mailhog"
+    default_web_path = "_extension/mailhog"
     """WebPath under which the UI is served (without leading or trailing slashes)"""
 
     default_smtp_port = 25
@@ -76,7 +76,7 @@ class MailHogServer(Server):
     def web_path(self):
         """Returns the configured path under which the web UI will be available when using path-based
         routing. This should be without trailing or prefixed slashes. by default, it results in
-        http://localhost:4566/mailhog."""
+        http://localhost:4566/_extension/mailhog."""
         return os.getenv("MH_UI_WEB_PATH") or self.default_web_path
 
     def _create_env_vars(self) -> dict:


### PR DESCRIPTION
## Reasoning 
In order to have the UI being able to access the web interface of extensions we need a standard that was set to be `extension-name.localhost.localstack.cloud` for subdomain and `localhost.localstack.cloud/_extension/extension-name` for submount (so also eph instance can access

## Changes

Moved submount to use `/_extension/` prefix

## Notes

I can see that we specifically get the "localhost" for localstack-core so I did not touch it but could we also changed it to "localhost.localstack.cloud"? I know that they resolve to the same thing so I think should not be a problem but in the console is a bit strange @thrau 
![image](https://github.com/user-attachments/assets/00ce8ead-ccca-4420-91eb-5204b789be45)
