### PR TITLE
Catch regex config errors in AWS proxy; fix logic for proxying S3 requests with host-based addressing

### DIFF
--- a/aws-replicator/Makefile
+++ b/aws-replicator/Makefile
@@ -49,7 +49,7 @@ enable: $(wildcard ./build/dist/localstack_extension_aws_replicator-*.tar.gz)  #
 		localstack extensions -v install file://$?
 
 publish: clean-dist venv dist
-	$(VENV_RUN); cd build; pip install --upgrade twine; twine upload dist/*
+	$(VENV_RUN); pip install --upgrade twine; twine upload dist/*
 
 clean-dist: clean
 	rm -rf dist/

--- a/aws-replicator/README.md
+++ b/aws-replicator/README.md
@@ -152,6 +152,7 @@ localstack extensions install "git+https://github.com/localstack/localstack-exte
 
 ## Change Log
 
+* `0.1.19`: Print human-readable message for invalid regexes in resource configs; fix logic for proxying S3 requests with host-based addressing
 * `0.1.18`: Update environment check to use SDK Docker client and enable starting the proxy from within Docker (e.g., from the LS main container as part of an init script)
 * `0.1.17`: Add basic support for ARN-based pattern-matching for `secretsmanager` resources
 * `0.1.16`: Update imports for localstack >=3.6 compatibility

--- a/aws-replicator/aws_replicator/client/auth_proxy.py
+++ b/aws-replicator/aws_replicator/client/auth_proxy.py
@@ -274,7 +274,7 @@ class AuthProxyAWS(Server):
 
     def _fix_host_and_path(self, request: Request, service_name: str):
         if service_name == "s3":
-            # fix the path and Host header, to avoid bucket addressing issues
+            # fix the path and prepend the bucket name, to avoid bucket addressing issues
             host = request.headers.pop(HEADER_HOST_ORIGINAL, None)
             host = host or request.headers.get("Host") or ""
             match = re.match(rf"(.+)\.s3\.{LOCALHOST_HOSTNAME}", host)

--- a/aws-replicator/aws_replicator/server/aws_request_forwarder.py
+++ b/aws-replicator/aws_replicator/server/aws_request_forwarder.py
@@ -22,6 +22,7 @@ try:
 except ImportError:
     from localstack.constants import TEST_AWS_ACCESS_KEY_ID
 
+from aws_replicator.shared.constants import HEADER_HOST_ORIGINAL
 from aws_replicator.shared.models import ProxyInstance, ProxyServiceConfig
 
 LOG = logging.getLogger(__name__)
@@ -145,7 +146,7 @@ class AwsProxyHandler(Handler):
 
         result = None
         try:
-            headers.pop("Host", None)
+            headers[HEADER_HOST_ORIGINAL] = headers.pop("Host", None)
             headers.pop("Content-Length", None)
             ctype = headers.get("Content-Type")
             data = b""

--- a/aws-replicator/aws_replicator/server/aws_request_forwarder.py
+++ b/aws-replicator/aws_replicator/server/aws_request_forwarder.py
@@ -98,33 +98,38 @@ class AwsProxyHandler(Handler):
     def _request_matches_resource(
         self, context: RequestContext, resource_name_pattern: str
     ) -> bool:
-        service_name = self._get_canonical_service_name(context.service.service_name)
-        if service_name == "s3":
-            bucket_name = context.service_request.get("Bucket") or ""
-            s3_bucket_arn = arns.s3_bucket_arn(bucket_name)
-            return bool(re.match(resource_name_pattern, s3_bucket_arn))
-        if service_name == "sqs":
-            queue_name = context.service_request.get("QueueName") or ""
-            queue_url = context.service_request.get("QueueUrl") or ""
-            queue_name = queue_name or queue_url.split("/")[-1]
-            candidates = (
-                queue_name,
-                queue_url,
-                sqs_queue_arn(
-                    queue_name, account_id=context.account_id, region_name=context.region
-                ),
-            )
-            for candidate in candidates:
-                if re.match(resource_name_pattern, candidate):
-                    return True
-            return False
-        if service_name == "secretsmanager":
-            secret_id = context.service_request.get("SecretId") or ""
-            secret_arn = secretsmanager_secret_arn(
-                secret_id, account_id=context.account_id, region_name=context.region
-            )
-            return bool(re.match(resource_name_pattern, secret_arn))
-        # TODO: add more resource patterns
+        try:
+            service_name = self._get_canonical_service_name(context.service.service_name)
+            if service_name == "s3":
+                bucket_name = context.service_request.get("Bucket") or ""
+                s3_bucket_arn = arns.s3_bucket_arn(bucket_name)
+                return bool(re.match(resource_name_pattern, s3_bucket_arn))
+            if service_name == "sqs":
+                queue_name = context.service_request.get("QueueName") or ""
+                queue_url = context.service_request.get("QueueUrl") or ""
+                queue_name = queue_name or queue_url.split("/")[-1]
+                candidates = (
+                    queue_name,
+                    queue_url,
+                    sqs_queue_arn(
+                        queue_name, account_id=context.account_id, region_name=context.region
+                    ),
+                )
+                for candidate in candidates:
+                    if re.match(resource_name_pattern, candidate):
+                        return True
+                return False
+            if service_name == "secretsmanager":
+                secret_id = context.service_request.get("SecretId") or ""
+                secret_arn = secretsmanager_secret_arn(
+                    secret_id, account_id=context.account_id, region_name=context.region
+                )
+                return bool(re.match(resource_name_pattern, secret_arn))
+            # TODO: add more resource patterns
+        except re.error as e:
+            raise Exception(
+                "Error evaluating regular expression - please verify proxy configuration"
+            ) from e
         return True
 
     def forward_request(self, context: RequestContext, proxy: ProxyInstance) -> requests.Response:

--- a/aws-replicator/aws_replicator/shared/constants.py
+++ b/aws-replicator/aws_replicator/shared/constants.py
@@ -1,0 +1,2 @@
+# header name for the original request host name forwarded in the request to the target proxy handler
+HEADER_HOST_ORIGINAL = "x-ls-host-original"

--- a/aws-replicator/setup.cfg
+++ b/aws-replicator/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = localstack-extension-aws-replicator
-version = 0.1.18
+version = 0.1.19
 summary = LocalStack Extension: AWS replicator
 description = Replicate AWS resources into your LocalStack instance
 long_description = file: README.md

--- a/aws-replicator/tests/test_proxy_requests.py
+++ b/aws-replicator/tests/test_proxy_requests.py
@@ -4,6 +4,7 @@ import gzip
 
 import boto3
 import pytest
+from botocore.client import Config
 from botocore.exceptions import ClientError
 from localstack.aws.connect import connect_to
 from localstack.utils.aws.arns import sqs_queue_arn, sqs_queue_url_for_arn
@@ -48,9 +49,12 @@ def test_s3_requests(start_aws_proxy, s3_create_bucket, metadata_gzip, host_addr
 
     # create clients
     if host_addressing:
-        s3_client = connect_to(endpoint_url="http://s3.localhost.localstack.cloud:4566").s3
+        s3_client = connect_to(
+            endpoint_url="http://s3.localhost.localstack.cloud:4566",
+            config=Config(s3={"addressing_style": "virtual"}),
+        ).s3
     else:
-        s3_client = connect_to(endpoint_url="http://localhost:4566").s3
+        s3_client = connect_to().s3
     s3_client_aws = boto3.client("s3")
 
     # list buckets to assert that proxy is up and running

--- a/aws-replicator/tests/test_proxy_requests.py
+++ b/aws-replicator/tests/test_proxy_requests.py
@@ -40,13 +40,17 @@ def start_aws_proxy():
 
 
 @pytest.mark.parametrize("metadata_gzip", [True, False])
-def test_s3_requests(start_aws_proxy, s3_create_bucket, metadata_gzip):
+@pytest.mark.parametrize("host_addressing", [True, False])
+def test_s3_requests(start_aws_proxy, s3_create_bucket, metadata_gzip, host_addressing):
     # start proxy
     config = ProxyConfig(services={"s3": {"resources": ".*"}}, bind_host=PROXY_BIND_HOST)
     start_aws_proxy(config)
 
     # create clients
-    s3_client = connect_to().s3
+    if host_addressing:
+        s3_client = connect_to(endpoint_url="http://s3.localhost.localstack.cloud:4566").s3
+    else:
+        s3_client = connect_to(endpoint_url="http://localhost:4566").s3
     s3_client_aws = boto3.client("s3")
 
     # list buckets to assert that proxy is up and running


### PR DESCRIPTION
Adjust regex logic to catch config errors in AWS proxy.

Addresses an issue where we've recently seen errors like this:
```
  File "/var/lib/localstack/lib/extensions/python_venv/lib/python3.11/site-packages/aws_replicator/server/aws_request_forwarder.py", line 74, in select_proxy
    resource_name_matches = any(
                            ^^^^
  File "/var/lib/localstack/lib/extensions/python_venv/lib/python3.11/site-packages/aws_replicator/server/aws_request_forwarder.py", line 75, in <genexpr>
    self._request_matches_resource(context, resource_name_pattern)
  File "/var/lib/localstack/lib/extensions/python_venv/lib/python3.11/site-packages/aws_replicator/server/aws_request_forwarder.py", line 105, in _request_matches_resource
    return bool(re.match(resource_name_pattern, s3_bucket_arn))
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/re/__init__.py", line 166, in match
    return _compile(pattern, flags).match(string)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/re/__init__.py", line 294, in _compile
    p = _compiler.compile(pattern, flags)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/re/_compiler.py", line 745, in compile
    p = _parser.parse(p, flags)
        ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/re/_parser.py", line 989, in parse
    p = _parse_sub(source, state, flags & SRE_FLAG_VERBOSE, 0)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/re/_parser.py", line 464, in _parse_sub
    itemsappend(_parse(source, state, verbose, nested + 1,
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/re/_parser.py", line 691, in _parse
    raise source.error("nothing to repeat",
re.error: nothing to repeat at position 0
```

We are not changing the logic per se in here, but at least make the error message more human-readable.

---

The PR also enhances the logic for proxying S3 requests with host-based addressing. This is required for AWS SDK S3 clients that are using host-based bucket addressing (e.g., AWS JavaScript SDK v2/v3 by default). We are now passing a `x-ls-host-original` from the original request handler to the proxy handler, and then extract the bucket name from that header value, to form the final request path (`/<bucket>/<path>`).

The tests have been extended with additional parametrization to cover this case (host-based as well as path-based bucket addressing) as well.