### PR TITLE
Document TERRAFORM_VERSION env var

### DIFF
--- a/terraform-init/README.md
+++ b/terraform-init/README.md
@@ -13,6 +13,7 @@ LocalStack Extension for using Terraform files in [init hooks](https://docs.loca
 ## Usage
 
 * Start localstack with `EXTENSION_AUTO_INSTALL="localstack-extension-terraform-init"`
+* Optionally specify `TERRAFORM_VERSION=1.9.5` (currently defaults to 1.5.7) 
 * Mount a `main.tf` file into `/etc/localstack/init/ready.d`
 
 When LocalStack starts up, it will install the extension, which in turn install `terraform` and `tflocal` into the container.


### PR DESCRIPTION
TERRAFORM_VERSION may be specified per https://github.com/localstack/localstack/blob/c8cfa257b67c5b8f36b10dcc43731da984e13951/localstack-core/localstack/packages/terraform.py#L10