### PR TITLE
Fix logic to proxy S3 requests against *amazonaws.com

### DIFF
--- a/aws-replicator/Makefile
+++ b/aws-replicator/Makefile
@@ -33,7 +33,7 @@ install: venv
 	$(VENV_RUN); $(PIP_CMD) install -e ".[test]"
 
 test: venv
-	$(VENV_RUN); python -m pytest $(TEST_PATH)
+	$(VENV_RUN); python -m pytest $(PYTEST_ARGS) $(TEST_PATH)
 
 dist: venv
 	$(VENV_RUN); python setup.py sdist bdist_wheel

--- a/aws-replicator/README.md
+++ b/aws-replicator/README.md
@@ -126,6 +126,7 @@ If you wish to access the deprecated instructions, they can be found [here](http
 
 ## Change Log
 
+* `0.1.20`: Fix logic for proxying S3 requests with `*.s3.amazonaws.com` host header
 * `0.1.19`: Print human-readable message for invalid regexes in resource configs; fix logic for proxying S3 requests with host-based addressing
 * `0.1.18`: Update environment check to use SDK Docker client and enable starting the proxy from within Docker (e.g., from the LS main container as part of an init script)
 * `0.1.17`: Add basic support for ARN-based pattern-matching for `secretsmanager` resources

--- a/aws-replicator/aws_replicator/client/auth_proxy.py
+++ b/aws-replicator/aws_replicator/client/auth_proxy.py
@@ -275,9 +275,10 @@ class AuthProxyAWS(Server):
     def _fix_host_and_path(self, request: Request, service_name: str):
         if service_name == "s3":
             # fix the path and prepend the bucket name, to avoid bucket addressing issues
+            regex_base_domain = rf"((amazonaws\.com)|({LOCALHOST_HOSTNAME}))"
             host = request.headers.pop(HEADER_HOST_ORIGINAL, None)
             host = host or request.headers.get("Host") or ""
-            match = re.match(rf"(.+)\.s3\.{LOCALHOST_HOSTNAME}", host)
+            match = re.match(rf"(.+)\.s3\.{regex_base_domain}", host)
             if match:
                 # prepend the bucket name (extracted from the host) to the path of the request (path-based addressing)
                 request.path = f"/{match.group(1)}{request.path}"

--- a/aws-replicator/setup.cfg
+++ b/aws-replicator/setup.cfg
@@ -1,8 +1,8 @@
 [metadata]
 name = localstack-extension-aws-replicator
-version = 0.1.19
-summary = LocalStack Extension: AWS replicator
-description = Replicate AWS resources into your LocalStack instance
+version = 0.1.20
+summary = LocalStack AWS Proxy Extension
+description = Proxy AWS resources into your LocalStack instance
 long_description = file: README.md
 long_description_content_type = text/markdown; charset=UTF-8
 url = https://github.com/localstack/localstack-extensions/tree/main/aws-replicator


### PR DESCRIPTION
Fix logic to proxy S3 requests against `*.s3.amazonaws.com` requests. 

Follow up for recent PR #80 , which introduced extraction of bucket names from hostnames in proxied requests. The previous PR only extracted the bucket from `<bucket>.s3.localhost.localstack.cloud` hosts, and with this PR we are now also supporting `<bucket>.s3.amazonaws.com` hosts. This can be required if, e.g., a request is being made from a Lambda using transparent endpoint injection.

A simple test has been added to cover the functionality - using a modified boto3 client that mimicks a local request using transparent endpoint injection, targeting the real AWS hostname locally. 