### PR TITLE
Fix AWS proxy extension not starting because of stale imports

### DIFF
--- a/aws-replicator/README.md
+++ b/aws-replicator/README.md
@@ -126,6 +126,7 @@ If you wish to access the deprecated instructions, they can be found [here](http
 
 ## Change Log
 
+* `0.1.21`: Fix auth-related imports that prevent the AWS proxy from starting
 * `0.1.20`: Fix logic for proxying S3 requests with `*.s3.amazonaws.com` host header
 * `0.1.19`: Print human-readable message for invalid regexes in resource configs; fix logic for proxying S3 requests with host-based addressing
 * `0.1.18`: Update environment check to use SDK Docker client and enable starting the proxy from within Docker (e.g., from the LS main container as part of an init script)

--- a/aws-replicator/aws_replicator/client/auth_proxy.py
+++ b/aws-replicator/aws_replicator/client/auth_proxy.py
@@ -55,9 +55,9 @@ if localstack_config.DEBUG:
     LOG.setLevel(logging.DEBUG)
 
 # TODO make configurable
-# CLI_PIP_PACKAGE = "localstack-extension-aws-replicator"
+CLI_PIP_PACKAGE = "localstack-extension-aws-replicator"
 # note: enable the line below temporarily for testing:
-CLI_PIP_PACKAGE = "git+https://github.com/localstack/localstack-extensions/@fix/aws-proxy-extension#egg=localstack-extension-aws-replicator&subdirectory=aws-replicator"
+# CLI_PIP_PACKAGE = "git+https://github.com/localstack/localstack-extensions/@branch#egg=localstack-extension-aws-replicator&subdirectory=aws-replicator"
 
 CONTAINER_NAME_PREFIX = "ls-aws-proxy-"
 CONTAINER_CONFIG_FILE = "/tmp/ls.aws.proxy.yml"

--- a/aws-replicator/aws_replicator/client/auth_proxy.py
+++ b/aws-replicator/aws_replicator/client/auth_proxy.py
@@ -55,9 +55,9 @@ if localstack_config.DEBUG:
     LOG.setLevel(logging.DEBUG)
 
 # TODO make configurable
-CLI_PIP_PACKAGE = "localstack-extension-aws-replicator"
+# CLI_PIP_PACKAGE = "localstack-extension-aws-replicator"
 # note: enable the line below temporarily for testing:
-# CLI_PIP_PACKAGE = "git+https://github.com/localstack/localstack-extensions/@branch#egg=localstack-extension-aws-replicator&subdirectory=aws-replicator"
+CLI_PIP_PACKAGE = "git+https://github.com/localstack/localstack-extensions/@fix/aws-proxy-extension#egg=localstack-extension-aws-replicator&subdirectory=aws-replicator"
 
 CONTAINER_NAME_PREFIX = "ls-aws-proxy-"
 CONTAINER_CONFIG_FILE = "/tmp/ls.aws.proxy.yml"

--- a/aws-replicator/aws_replicator/client/cli.py
+++ b/aws-replicator/aws_replicator/client/cli.py
@@ -9,22 +9,22 @@ from localstack.utils.files import load_file
 
 from aws_replicator.shared.models import ProxyConfig, ProxyServiceConfig
 
-try:
-    from localstack.pro.core.bootstrap.auth import get_auth_headers
+try:    
+    from localstack.pro.core.bootstrap.auth import get_platform_auth_headers
     from localstack.pro.core.cli.aws import aws
-    from localstack.pro.core.config import is_api_key_configured
+    from localstack.pro.core.config import is_auth_token_configured
 except ImportError:
-    # TODO remove once we don't need compatibility with <3.6 anymore
-    from localstack_ext.bootstrap.auth import get_auth_headers
-    from localstack_ext.cli.aws import aws
-    from localstack_ext.config import is_api_key_configured
+    # Only support anything over version 3.6
+    from localstack.pro.core.bootstrap.auth import get_auth_headers as get_platform_auth_headers
+    from localstack.pro.core.cli.aws import aws
+    from localstack.pro.core.config import is_api_key_configured as is_auth_token_configured
 
 
 class AwsReplicatorPlugin(LocalstackCliPlugin):
     name = "aws-replicator"
 
     def should_load(self) -> bool:
-        return _is_logged_in() or is_api_key_configured()
+        return _is_logged_in() or is_auth_token_configured()
 
     def attach(self, cli: LocalstackCli) -> None:
         group: click.Group = cli.group
@@ -37,7 +37,7 @@ class AwsReplicatorPlugin(LocalstackCliPlugin):
 # TODO: remove over time as we're phasing out the `login` command
 def _is_logged_in() -> bool:
     try:
-        get_auth_headers()
+        get_platform_auth_headers()
         return True
     except Exception:
         return False

--- a/aws-replicator/aws_replicator/client/cli.py
+++ b/aws-replicator/aws_replicator/client/cli.py
@@ -9,7 +9,7 @@ from localstack.utils.files import load_file
 
 from aws_replicator.shared.models import ProxyConfig, ProxyServiceConfig
 
-try:    
+try:
     from localstack.pro.core.bootstrap.auth import get_platform_auth_headers
     from localstack.pro.core.cli.aws import aws
     from localstack.pro.core.config import is_auth_token_configured

--- a/aws-replicator/setup.cfg
+++ b/aws-replicator/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = localstack-extension-aws-replicator
-version = 0.1.20
+version = 0.1.21
 summary = LocalStack AWS Proxy Extension
 description = Proxy AWS resources into your LocalStack instance
 long_description = file: README.md


### PR DESCRIPTION
#### Description

This is directly causing the extension to not start. This is also happening as a consequence of us moving to version 4.0 of LocalStack.

This is currently blocking Audacy from running their local envs.