### PR TITLE
Pin wrangler version to fix hanging miniflare invocations

### DIFF
--- a/aws-replicator/aws_replicator/client/auth_proxy.py
+++ b/aws-replicator/aws_replicator/client/auth_proxy.py
@@ -278,7 +278,7 @@ class AuthProxyAWS(Server):
             regex_base_domain = rf"((amazonaws\.com)|({LOCALHOST_HOSTNAME}))"
             host = request.headers.pop(HEADER_HOST_ORIGINAL, None)
             host = host or request.headers.get("Host") or ""
-            match = re.match(rf"(.+)\.s3\.{regex_base_domain}", host)
+            match = re.match(rf"(.+)\.s3\..*{regex_base_domain}", host)
             if match:
                 # prepend the bucket name (extracted from the host) to the path of the request (path-based addressing)
                 request.path = f"/{match.group(1)}{request.path}"

--- a/aws-replicator/tests/test_proxy_requests.py
+++ b/aws-replicator/tests/test_proxy_requests.py
@@ -65,7 +65,7 @@ def test_s3_requests(start_aws_proxy, s3_create_bucket, metadata_gzip, target_en
             url = urlparse(request.url)
             match = re.match(r"(.+)\.s3\.localhost\.localstack\.cloud", url.netloc)
             if match:
-                request.headers.add_header("host", f"{match.group(1)}.s3.amazonaws.com")
+                request.headers.add_header("host", f"{match.group(1)}.s3.us-east-1.amazonaws.com")
 
         s3_client.meta.events.register_first("before-sign.*.*", _add_header)
 

--- a/miniflare/Makefile
+++ b/miniflare/Makefile
@@ -18,10 +18,10 @@ clean:
 	rm -rf *.egg-info/
 
 lint:              		  ## Run code linter to check code style
-	$(VENV_RUN); python -m pflake8 --show-source --ignore=E501
+	$(VENV_RUN); python -m pflake8 --show-source --ignore=E501 --exclude .venv,build
 
 format:            		  ## Run black and isort code formatter
-	$(VENV_RUN); python -m isort .; python -m black .
+	$(VENV_RUN); python -m isort .; python -m black miniflare
 
 install: venv
 	$(VENV_RUN); python -m pip install -e .[dev]

--- a/miniflare/README.md
+++ b/miniflare/README.md
@@ -34,6 +34,7 @@ Hello World!
 
 ## Change Log
 
+* `0.1.2`: Pin wrangler version to fix hanging miniflare invocations; fix encoding headers for invocation responses
 * `0.1.1`: Adapt for LocalStack v3.0
 * `0.1.0`: Upgrade to Miniflare 3.0
 * `0.0.1`: Initial version.

--- a/miniflare/miniflare/cloudflare_api.py
+++ b/miniflare/miniflare/cloudflare_api.py
@@ -42,13 +42,19 @@ def handle_invocation(request: Request, path: str, script_name: str, port: str):
     port = SCRIPT_SERVERS[script_name].port
     response = requests.request(
         method=request.method,
-        url=f"http://localhost:{port}{request.path}",
+        url=f"http://localhost:{port}/{path}",
         data=request.get_data(),
     )
     result = Response()
     result.status_code = response.status_code
     result.set_data(response.content)
-    result.headers.update(dict(response.headers))
+    headers = dict(response.headers)
+    if headers.get('Transfer-Encoding') == 'chunked':
+        headers.pop('Transfer-Encoding')
+    if headers.get('Content-Encoding') == 'gzip':
+        headers.pop('Content-Encoding')
+    LOG.debug("Miniflare invocation response headers/body: %s / %s", headers, response.content)
+    result.headers.update(headers)
     return result
 
 

--- a/miniflare/miniflare/cloudflare_api.py
+++ b/miniflare/miniflare/cloudflare_api.py
@@ -154,8 +154,10 @@ def handle_services(request: Request, account_id: str, service_name: str) -> dic
         }
     )
 
+
 def handle_standard(request: Request, account_id: str) -> dict:
     return _wrap({})
+
 
 def handle_subdomain(request: Request, account_id: str) -> dict:
     return _wrap({})

--- a/miniflare/setup.cfg
+++ b/miniflare/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = localstack-extension-miniflare
-version = 0.1.2
+version = 0.1.3
 summary = LocalStack Extension: Miniflare
 description = This extension makes Miniflare (dev environment for Cloudflare workers) available directly in LocalStack
 long_description = file: README.md


### PR DESCRIPTION
This PR contains a few fixes to make the Miniflare extension compatible with the latest version of `wrangler`, and with LocalStack 4.0:

* pin wrangler version to fix hanging miniflare invocations
* remove installation of `miniflare` npm package, as the dev mode is now natively integrated into `wrangler` directly
* fix encoding headers for invocation responses