### PR TITLE
fix: fix broken react script source urls

### DIFF
--- a/aws-replicator/README.md
+++ b/aws-replicator/README.md
@@ -126,6 +126,7 @@ If you wish to access the deprecated instructions, they can be found [here](http
 
 ## Change Log
 
+* `0.1.23`: Fix unpinned React.js dependencies preventing webui from loading
 * `0.1.22`: Fix auth-related imports that prevent the AWS proxy from starting
 * `0.1.20`: Fix logic for proxying S3 requests with `*.s3.amazonaws.com` host header
 * `0.1.19`: Print human-readable message for invalid regexes in resource configs; fix logic for proxying S3 requests with host-based addressing

--- a/aws-replicator/aws_replicator/server/ui/index.html
+++ b/aws-replicator/aws_replicator/server/ui/index.html
@@ -4,8 +4,8 @@
     <meta charset="utf-8">
     <title>AWS Replicator - LocalStack Extension</title>
     <link rel="shortcut icon" href="/favicon.png" />
-    <script src="https://unpkg.com/react/umd/react.development.js"></script>
-    <script src="https://unpkg.com/react-dom/umd/react-dom.development.js"></script>
+    <script src="https://unpkg.com/react@18.3.1/umd/react.development.js"></script>
+    <script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js"></script>
     <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/axios@0.18.0/dist/axios.min.js"></script>
     <script src="https://unpkg.com/@mui/material@5.14.13/umd/material-ui.development.js"></script>

--- a/aws-replicator/setup.cfg
+++ b/aws-replicator/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = localstack-extension-aws-replicator
-version = 0.1.22
+version = 0.1.23
 summary = LocalStack AWS Proxy Extension
 description = Proxy AWS resources into your LocalStack instance
 long_description = file: README.md


### PR DESCRIPTION
PR fixes the (currently broken) script source URLs for the `aws-replicator` extension's built-in webui, specifically by pinning them to the correct version.