### PR TITLE
[Prometheus] Clarify propagation delay description in docs

### DIFF
--- a/prometheus/docs/localstack_metrics.md
+++ b/prometheus/docs/localstack_metrics.md
@@ -64,7 +64,7 @@
 
 `localstack_event_propagation_delay_seconds`
 
-- **Description:** End-to-end latency between event creation and processing
+- **Description:** End-to-end latency between event creation (at source) until just before being sent to a target for processing.
 - **Labels:** `event_source`, `event_target`
 - **Type:** histogram
 

--- a/prometheus/localstack_prometheus/metrics/event_processing.py
+++ b/prometheus/localstack_prometheus/metrics/event_processing.py
@@ -23,7 +23,7 @@ LOCALSTACK_IN_FLIGHT_EVENTS_GAUGE = Gauge(
 # Performance and latency metrics
 LOCALSTACK_EVENT_PROPAGATION_DELAY_SECONDS = Histogram(
     "localstack_event_propagation_delay_seconds",
-    "End-to-end latency between event creation and processing",
+    "End-to-end latency between event creation (at source) until just before being sent to a target for processing.",
     ["event_source", "event_target"],
     buckets=[0.005, 0.05, 0.5, 5, 30, 60, 300, 900, 3600],
 )


### PR DESCRIPTION
## Context

Clarifies that `localstack_event_propagation_delay_seconds` measures from record creation until right before sending events onto a target.