### PR TITLE
Run workflows nightly to catch regressions due to core changes

### DIFF
--- a/.github/workflows/keycloak.yml
+++ b/.github/workflows/keycloak.yml
@@ -1,6 +1,8 @@
 name: LocalStack Keycloak Extension Tests
 
 on:
+  schedule:
+    - cron: '0 2 * * 1-5'
   push:
     paths:
       - keycloak/**

--- a/.github/workflows/miniflare.yml
+++ b/.github/workflows/miniflare.yml
@@ -1,6 +1,8 @@
 name: LocalStack Miniflare Extension Tests
 
 on:
+  schedule:
+    - cron: '0 2 * * 1-5'
   push:
     paths:
       - miniflare/**

--- a/.github/workflows/paradedb.yml
+++ b/.github/workflows/paradedb.yml
@@ -1,6 +1,8 @@
 name: LocalStack ParadeDB Extension Tests
 
 on:
+  schedule:
+    - cron: '0 2 * * 1-5'
   push:
     paths:
       - paradedb/**

--- a/.github/workflows/typedb.yml
+++ b/.github/workflows/typedb.yml
@@ -1,6 +1,8 @@
 name: LocalStack TypeDB Extension Tests
 
 on:
+  schedule:
+    - cron: '0 2 * * 1-5'
   push:
     paths:
       - typedb/**

--- a/.github/workflows/utils.yml
+++ b/.github/workflows/utils.yml
@@ -1,6 +1,8 @@
 name: LocalStack Extensions Utils Tests
 
 on:
+  schedule:
+    - cron: '0 2 * * 1-5'
   push:
     paths:
       - utils/**

--- a/.github/workflows/wiremock.yml
+++ b/.github/workflows/wiremock.yml
@@ -1,6 +1,8 @@
 name: LocalStack WireMock Extension Tests
 
 on:
+  schedule:
+    - cron: '0 2 * * 1-5'
   pull_request:
     branches:
       - main


### PR DESCRIPTION
As @alexrashed and I move things around in the core, we intend to manage the future of these extensions, which might include knowingly discontinuing them. As a backstop, we'd at least like to make sure that we don't break them unknowingly.