### PR TITLE
fix(prometheus): repoint Lambda imports

### DIFF
--- a/prometheus/localstack_prometheus/instruments/lambda_.py
+++ b/prometheus/localstack_prometheus/instruments/lambda_.py
@@ -1,14 +1,14 @@
 import contextlib
 from typing import ContextManager
 
-from localstack.services.lambda_.invocation.assignment import AssignmentService
-from localstack.services.lambda_.invocation.docker_runtime_executor import (
+from localstack.pro.core.services.lambda_.invocation.assignment import AssignmentService
+from localstack.pro.core.services.lambda_.invocation.docker_runtime_executor import (
     DockerRuntimeExecutor,
 )
-from localstack.services.lambda_.invocation.execution_environment import (
+from localstack.pro.core.services.lambda_.invocation.execution_environment import (
     ExecutionEnvironment,
 )
-from localstack.services.lambda_.invocation.lambda_models import (
+from localstack.pro.core.services.lambda_.invocation.lambda_models import (
     FunctionVersion,
     InitializationType,
 )

--- a/prometheus/localstack_prometheus/instruments/patch.py
+++ b/prometheus/localstack_prometheus/instruments/patch.py
@@ -1,19 +1,19 @@
 import logging
 
-from localstack.services.lambda_.event_source_mapping.pollers.dynamodb_poller import (
+from localstack.pro.core.services.lambda_.event_source_mapping.pollers.dynamodb_poller import (
     DynamoDBPoller,
 )
-from localstack.services.lambda_.event_source_mapping.pollers.kinesis_poller import (
+from localstack.pro.core.services.lambda_.event_source_mapping.pollers.kinesis_poller import (
     KinesisPoller,
 )
-from localstack.services.lambda_.event_source_mapping.pollers.sqs_poller import (
+from localstack.pro.core.services.lambda_.event_source_mapping.pollers.sqs_poller import (
     SqsPoller,
 )
-from localstack.services.lambda_.event_source_mapping.senders.lambda_sender import (
+from localstack.pro.core.services.lambda_.event_source_mapping.senders.lambda_sender import (
     LambdaSender,
 )
-from localstack.services.lambda_.invocation.assignment import AssignmentService
-from localstack.services.lambda_.invocation.docker_runtime_executor import (
+from localstack.pro.core.services.lambda_.invocation.assignment import AssignmentService
+from localstack.pro.core.services.lambda_.invocation.docker_runtime_executor import (
     DockerRuntimeExecutor,
 )
 from localstack.utils.patch import Patch, Patches

--- a/prometheus/localstack_prometheus/instruments/poller.py
+++ b/prometheus/localstack_prometheus/instruments/poller.py
@@ -1,6 +1,6 @@
 import logging
 
-from localstack.services.lambda_.event_source_mapping.pollers.poller import (
+from localstack.pro.core.services.lambda_.event_source_mapping.pollers.poller import (
     EmptyPollResultsException,
     Poller,
 )

--- a/prometheus/localstack_prometheus/instruments/sender.py
+++ b/prometheus/localstack_prometheus/instruments/sender.py
@@ -1,7 +1,7 @@
 import logging
 import time
 
-from localstack.services.lambda_.event_source_mapping.senders.sender import Sender
+from localstack.pro.core.services.lambda_.event_source_mapping.senders.sender import Sender
 
 from localstack_prometheus.metrics.event_processing import (
     LOCALSTACK_EVENT_PROCESSING_ERRORS_TOTAL,

--- a/prometheus/localstack_prometheus/instruments/sqs_poller.py
+++ b/prometheus/localstack_prometheus/instruments/sqs_poller.py
@@ -1,6 +1,6 @@
 import logging
 
-from localstack.services.lambda_.event_source_mapping.pollers.sqs_poller import (
+from localstack.pro.core.services.lambda_.event_source_mapping.pollers.sqs_poller import (
     SqsPoller,
 )
 

--- a/prometheus/localstack_prometheus/instruments/stream_poller.py
+++ b/prometheus/localstack_prometheus/instruments/stream_poller.py
@@ -1,4 +1,4 @@
-from localstack.services.lambda_.event_source_mapping.pollers.stream_poller import (
+from localstack.pro.core.services.lambda_.event_source_mapping.pollers.stream_poller import (
     StreamPoller,
 )
 

--- a/prometheus/localstack_prometheus/instruments/util.py
+++ b/prometheus/localstack_prometheus/instruments/util.py
@@ -1,4 +1,4 @@
-from localstack.services.lambda_.event_source_mapping.esm_event_processor import (
+from localstack.pro.core.services.lambda_.event_source_mapping.esm_event_processor import (
     EsmEventProcessor,
     EventProcessor,
 )


### PR DESCRIPTION
## Motivation

The prometheus extension instruments LocalStack's Lambda event-source-mapping pollers/senders and invocation internals. Those modules moved from the community localstack package (`localstack.services.lambda_.*`) into localstack-pro-core (`localstack.pro.core.services.lambda_.*`). As a result the extension fails to import.

## Changes

Repoint the affected imports from `localstack.services.lambda_.*` to `localstack.pro.core.services.lambda_.*` across `instruments/`:

- `event_source_mapping.pollers.{poller,stream_poller,sqs_poller,dynamodb_poller,kinesis_poller}`
- `event_source_mapping.senders.{sender,lambda_sender}`
- `event_source_mapping.esm_event_processor`
- `invocation.{assignment,docker_runtime_executor,execution_environment,lambda_models}`

## Alternatives
I think this extension might not be used lately, and this could have been superseded by AppInspector, so maybe we just want to sunset the whole extension?