### PR TITLE
Run CI against both :latest and :dev images

### DIFF
--- a/.github/workflows/keycloak.yml
+++ b/.github/workflows/keycloak.yml
@@ -5,6 +5,7 @@ on:
     - cron: '0 2 * * 1-5'
   push:
     paths:
+      - .github/workflows/keycloak.yml
       - keycloak/**
     branches:
       - main

--- a/.github/workflows/keycloak.yml
+++ b/.github/workflows/keycloak.yml
@@ -25,6 +25,13 @@ jobs:
     permissions:
       contents: read
     timeout-minutes: 15
+    strategy:
+      matrix:
+        tag:
+          - latest
+          - dev
+    env:
+      IMAGE_NAME: localstack/localstack-pro:${{matrix.tag}}
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -35,8 +42,8 @@ jobs:
         run: |
           cd keycloak
 
-          docker pull localstack/localstack-pro &
-          docker pull quay.io/keycloak/keycloak:26.0 &
+          docker pull "$IMAGE_NAME"
+          docker pull quay.io/keycloak/keycloak:26.0
           pip install localstack
 
           make install

--- a/.github/workflows/miniflare.yml
+++ b/.github/workflows/miniflare.yml
@@ -5,6 +5,7 @@ on:
     - cron: '0 2 * * 1-5'
   push:
     paths:
+      - .github/workflows/miniflare.yml
       - miniflare/**
     branches:
       - main

--- a/.github/workflows/miniflare.yml
+++ b/.github/workflows/miniflare.yml
@@ -23,6 +23,13 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    strategy:
+      matrix:
+        tag:
+          - latest
+          - dev
+    env:
+      IMAGE_NAME: localstack/localstack-pro:${{matrix.tag}}
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -33,7 +40,7 @@ jobs:
         run: |
           cd miniflare
 
-          docker pull localstack/localstack-pro &
+          docker pull "$IMAGE_NAME"
           pip install localstack
 
           make install

--- a/.github/workflows/paradedb.yml
+++ b/.github/workflows/paradedb.yml
@@ -25,6 +25,13 @@ jobs:
     permissions:
       contents: read
     timeout-minutes: 10
+    strategy:
+      matrix:
+        tag:
+          - latest
+          - dev
+    env:
+      IMAGE_NAME: localstack/localstack-pro:${{matrix.tag}}
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -35,8 +42,8 @@ jobs:
         run: |
           cd paradedb
 
-          docker pull localstack/localstack-pro &
-          docker pull paradedb/paradedb &
+          docker pull "$IMAGE_NAME"
+          docker pull paradedb/paradedb
           pip install localstack
 
           make install

--- a/.github/workflows/paradedb.yml
+++ b/.github/workflows/paradedb.yml
@@ -5,6 +5,7 @@ on:
     - cron: '0 2 * * 1-5'
   push:
     paths:
+      - .github/workflows/paradedb.yml
       - paradedb/**
     branches:
       - main

--- a/.github/workflows/typedb.yml
+++ b/.github/workflows/typedb.yml
@@ -5,6 +5,7 @@ on:
     - cron: '0 2 * * 1-5'
   push:
     paths:
+      - .github/workflows/typedb.yml
       - typedb/**
     branches:
       - main

--- a/.github/workflows/typedb.yml
+++ b/.github/workflows/typedb.yml
@@ -25,6 +25,13 @@ jobs:
     permissions:
       contents: read
     timeout-minutes: 10
+    strategy:
+      matrix:
+        tag:
+          - latest
+          - dev
+    env:
+      IMAGE_NAME: localstack/localstack-pro:${{matrix.tag}}
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -35,8 +42,8 @@ jobs:
         run: |
           cd typedb
 
-          docker pull localstack/localstack-pro &
-          docker pull typedb/typedb &
+          docker pull "$IMAGE_NAME"
+          docker pull typedb/typedb
           pip install localstack
 
           make install

--- a/.github/workflows/wiremock.yml
+++ b/.github/workflows/wiremock.yml
@@ -26,6 +26,13 @@ jobs:
     permissions:
       contents: read
     timeout-minutes: 10
+    strategy:
+      matrix:
+        tag:
+          - latest
+          - dev
+    env:
+      IMAGE_NAME: localstack/localstack-pro:${{matrix.tag}}
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -39,9 +46,9 @@ jobs:
         run: |
           cd wiremock
 
-          docker pull localstack/localstack-pro &
-          docker pull wiremock/wiremock &
-          docker pull public.ecr.aws/lambda/python:3.12 &
+          docker pull "$IMAGE_NAME"
+          docker pull wiremock/wiremock
+          docker pull public.ecr.aws/lambda/python:3.12
           pip install localstack terraform-local awscli-local[ver1]
 
           make install

--- a/.github/workflows/wiremock.yml
+++ b/.github/workflows/wiremock.yml
@@ -7,11 +7,13 @@ on:
     branches:
       - main
     paths:
+      - .github/workflows/wiremock.yml
       - 'wiremock/**'
   push:
     branches:
       - main
     paths:
+      - .github/workflows/wiremock.yml
       - 'wiremock/**'
   workflow_dispatch:
 


### PR DESCRIPTION
We want to catch regressions as soon as possible to avoid unplanned disruption, which means explicitly running CI against both `latest` and `dev`.

(It turned out `localstack` CLI was still defaulting to `:dev`, which we are fixing separately.)